### PR TITLE
다크 모드와 라이트 모드 테마 추가 및 코드 리팩토링

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,13 @@
-import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:untitled/pages/chat.dart';
+import 'package:untitled/pages/home.dart';
+import 'package:untitled/pages/like.dart';
+import 'package:untitled/pages/settings.dart';
 import 'package:untitled/presenter/themes/mode/dark_app_theme.dart';
 import 'package:untitled/presenter/themes/mode/light_app_theme.dart';
 import 'package:untitled/provider/theme_provider.dart';
+import 'package:untitled/widgets/navigation.dart';
 
 void main() {
   runApp(
@@ -75,148 +79,6 @@ class _MainScreenState extends State<MainScreen> {
               currentPageIndex = index;
             });
           },
-        ),
-      ),
-    );
-  }
-}
-
-class Navigation extends StatelessWidget {
-  final int currentPageIndex;
-  final ValueChanged<int> onDestinationSelected;
-
-  const Navigation({
-    required this.currentPageIndex,
-    required this.onDestinationSelected,
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return NavigationBar(
-      destinations: const [
-        NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
-        NavigationDestination(icon: Icon(Icons.favorite), label: 'Like'),
-        NavigationDestination(icon: Icon(Icons.chat), label: 'Chat'),
-        NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
-      ],
-      selectedIndex: currentPageIndex,
-      onDestinationSelected: onDestinationSelected,
-    );
-  }
-}
-
-class Home extends StatelessWidget {
-  const Home({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Text(
-            'Home Page',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 20),
-          IconButton(
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (BuildContext context) => const NavigatorTestPage(),
-                ),
-              );
-            },
-            icon: const Icon(Icons.home, size: 100, color: Colors.blue),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class Like extends StatelessWidget {
-  const Like({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.favorite, size: 100, color: Colors.red),
-          SizedBox(height: 20),
-          Text(
-            'Favorite Stocks',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class Chat extends StatelessWidget {
-  const Chat({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.chat, size: 100, color: Colors.green),
-          SizedBox(height: 20),
-          Text(
-            'Let\'s Talk',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class Settings extends StatelessWidget {
-  const Settings({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.settings, size: 100, color: Colors.grey),
-          SizedBox(height: 20),
-          Text(
-            'App Settings',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class NavigatorTestPage extends StatelessWidget {
-  const NavigatorTestPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        elevation: 0,
-      ),
-      body: const Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              'Test Success',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            ),
-          ],
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,10 +59,12 @@ class _MainScreenState extends State<MainScreen> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        backgroundColor: Colors.grey[200],
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         appBar: AppBar(
           backgroundColor: Colors.transparent,
-          title: const Text('MainScreen'),
+          title: const Text(
+            'MainScreen',
+          ),
           elevation: 0,
         ),
         body: AnimatedSwitcher(

--- a/lib/pages/chat.dart
+++ b/lib/pages/chat.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class Chat extends StatelessWidget {
+  const Chat({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.chat, size: 100, color: Colors.green),
+          SizedBox(height: 20),
+          Text(
+            'Let\'s Talk',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,30 +1,43 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:untitled/pages/navigator_test_page.dart';
+import 'package:untitled/provider/theme_provider.dart';
 
 class Home extends StatelessWidget {
   const Home({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final switchDarkMode = Provider.of<ThemeProvider>(context);
+
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Text(
-            'Home Page',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 20),
-          IconButton(
-            onPressed: () {
+          GestureDetector(
+            onTap: () {
               Navigator.of(context).push(
                 MaterialPageRoute<void>(
                   builder: (BuildContext context) => const NavigatorTestPage(),
                 ),
               );
             },
-            icon: const Icon(Icons.home, size: 100, color: Colors.blue),
+            child: const Icon(Icons.home, size: 100, color: Colors.blue),
           ),
+          const SizedBox(height: 20),
+          const Text(
+            'Home Page',
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          GestureDetector(
+              onTap: () {
+                switchDarkMode.toggleThemeMode();
+              },
+              child:
+                  const Icon(Icons.dark_mode, size: 100, color: Colors.blue)),
         ],
       ),
     );

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:untitled/pages/navigator_test_page.dart';
+
+class Home extends StatelessWidget {
+  const Home({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text(
+            'Home Page',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 20),
+          IconButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (BuildContext context) => const NavigatorTestPage(),
+                ),
+              );
+            },
+            icon: const Icon(Icons.home, size: 100, color: Colors.blue),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/like.dart
+++ b/lib/pages/like.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class Like extends StatelessWidget {
+  const Like({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.favorite, size: 100, color: Colors.red),
+          SizedBox(height: 20),
+          Text(
+            'Favorite Stocks',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/navigator_test_page.dart
+++ b/lib/pages/navigator_test_page.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class NavigatorTestPage extends StatelessWidget {
+  const NavigatorTestPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        elevation: 0,
+      ),
+      body: const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'Test Success',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class Settings extends StatelessWidget {
+  const Settings({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.settings, size: 100, color: Colors.grey),
+          SizedBox(height: 20),
+          Text(
+            'App Settings',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presenter/colors/app_colors.dart
+++ b/lib/presenter/colors/app_colors.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+
+}

--- a/lib/presenter/colors/app_colors.dart
+++ b/lib/presenter/colors/app_colors.dart
@@ -1,5 +1,29 @@
 import 'package:flutter/material.dart';
 
 class AppColors {
+  // LightMode
+  static const Color lightScaffoldBackground = Color(0xFFF7F7F7);
+  static const Color lightSearchBarColor = Color(0xFFFFFFFF);
+  static const Color lightTabBarColor = Color(0xFFD9D9D9);
+  static const Color lightButtonColor = Color(0xFFE8F0FD);
+  static const Color lightButtonIconColor = Color(0xFF4478E2);
+  static const Color lightTextColor = Color(0xFF000000);
+  static const Color lightTitleColor = Color(0xFF707070);
 
+  // DarkMode
+  static const Color darkScaffoldBackground = Color(0xFF303030);
+  static const Color darkSearchBarColor = Color(0xFF424242);
+  static const Color darkTabBarColor = Color(0xFF424242);
+  static const Color darkButtonColor = Color(0xFF3D80DE);
+  static const Color darkButtonIconColor = Color(0xFFC5D9F4);
+  static const Color darkTextColor = Color(0xFFFFFFFF);
+  static const Color darkTitleColor = Color(0xFFC0C0C0);
+
+  static const Color surface = Color(0xFFFFFFFF);
+  static const Color error = Color(0xFFB00020);
+  static const Color onPrimary = Color(0xFFFFFFFF);
+  static const Color onSecondary = Color(0xFF000000);
+  static const Color onBackground = Color(0xFF000000);
+  static const Color onSurface = Color(0xFF000000);
+  static const Color onError = Color(0xFFFFFFFF);
 }

--- a/lib/presenter/colors/app_theme_colors.dart
+++ b/lib/presenter/colors/app_theme_colors.dart
@@ -1,0 +1,5 @@
+
+
+class AppThemeColors {
+
+}

--- a/lib/presenter/colors/app_theme_colors.dart
+++ b/lib/presenter/colors/app_theme_colors.dart
@@ -1,5 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:untitled/presenter/colors/app_colors.dart';
 
-
+// [AppThemeColors] : AppColors에 정의된 색상들을 사용하여 테마에 필요한 색상 팔레트를 구성
 class AppThemeColors {
+  final Color scaffoldBackground;
+  final Color searchBarColor;
+  final Color tabBarColor;
+  final Color buttonColor;
+  final Color buttonIconColor;
+  final Color textColor;
+  final Color titleColor;
+  final Color surface;
+  final Color error;
+  final Color onPrimary;
+  final Color onSecondary;
+  final Color onBackground;
+  final Color onSurface;
+  final Color onError;
 
+  const AppThemeColors({
+    required this.scaffoldBackground,
+    required this.searchBarColor,
+    required this.tabBarColor,
+    required this.buttonColor,
+    required this.buttonIconColor,
+    required this.textColor,
+    required this.titleColor,
+    required this.surface,
+    required this.error,
+    required this.onPrimary,
+    required this.onSecondary,
+    required this.onBackground,
+    required this.onSurface,
+    required this.onError,
+  });
+
+  static AppThemeColors fromAppColors({
+    required bool isDarkMode,
+  }) {
+    return AppThemeColors(
+      scaffoldBackground: isDarkMode
+          ? AppColors.darkScaffoldBackground
+          : AppColors.lightScaffoldBackground,
+      searchBarColor: isDarkMode
+          ? AppColors.darkSearchBarColor
+          : AppColors.lightSearchBarColor,
+      tabBarColor:
+          isDarkMode ? AppColors.darkTabBarColor : AppColors.lightTabBarColor,
+      buttonColor:
+          isDarkMode ? AppColors.darkButtonColor : AppColors.lightButtonColor,
+      buttonIconColor: isDarkMode
+          ? AppColors.darkButtonIconColor
+          : AppColors.lightButtonIconColor,
+      textColor:
+          isDarkMode ? AppColors.darkTextColor : AppColors.lightTextColor,
+      titleColor:
+          isDarkMode ? AppColors.darkTitleColor : AppColors.lightTitleColor,
+      surface: AppColors.surface,
+      error: AppColors.error,
+      onPrimary: AppColors.onPrimary,
+      onSecondary: AppColors.onSecondary,
+      onBackground: AppColors.onBackground,
+      onSurface: AppColors.onSurface,
+      onError: AppColors.onError,
+    );
+  }
+
+  AppThemeColors lerp(covariant dynamic other, double t) {
+    if (other is! AppThemeColors) {
+      return this;
+    }
+    return AppThemeColors(
+      scaffoldBackground:
+          Color.lerp(scaffoldBackground, other.scaffoldBackground, t)!,
+      searchBarColor: Color.lerp(searchBarColor, other.searchBarColor, t)!,
+      tabBarColor: Color.lerp(tabBarColor, other.tabBarColor, t)!,
+      buttonColor: Color.lerp(buttonColor, other.buttonColor, t)!,
+      buttonIconColor: Color.lerp(buttonIconColor, other.buttonIconColor, t)!,
+      textColor: Color.lerp(textColor, other.textColor, t)!,
+      titleColor: Color.lerp(titleColor, other.titleColor, t)!,
+      surface: Color.lerp(surface, other.surface, t)!,
+      error: Color.lerp(error, other.error, t)!,
+      onPrimary: Color.lerp(onPrimary, other.onPrimary, t)!,
+      onSecondary: Color.lerp(onSecondary, other.onSecondary, t)!,
+      onBackground: Color.lerp(onBackground, other.onBackground, t)!,
+      onSurface: Color.lerp(onSurface, other.onSurface, t)!,
+      onError: Color.lerp(onError, other.onError, t)!,
+    );
+  }
 }

--- a/lib/presenter/themes/app_theme.dart
+++ b/lib/presenter/themes/app_theme.dart
@@ -1,8 +1,32 @@
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
+import 'package:untitled/presenter/colors/app_theme_colors.dart';
+import 'package:untitled/presenter/themes/app_theme_typography.dart';
+import 'package:untitled/utils/font_family.dart';
+
+import 'app_theme_styles.dart';
 
 class AppTheme extends ThemeExtension<AppTheme> {
-  ThemeData get themeData => ThemeData().copyWith(
+
+  final String name;
+  final String fontFamily;
+  final Brightness brightness;
+  // final AppThemeColors colors;
+  // final AppThemeTypography typography;
+  // final AppThemeStyles styles;
+
+  AppTheme({
+    required this.name,
+    required this.brightness,
+    // required this.colors,
+    // this.styles = const AppThemeStyles(),
+    // this.typography = const AppThemeTypography(),
+    this.fontFamily = FontFamily.circularStd,
+  });
+
+
+  ThemeData get themeData =>
+      ThemeData().copyWith(
         pageTransitionsTheme: const PageTransitionsTheme(
           builders: <TargetPlatform, PageTransitionsBuilder>{
             TargetPlatform.android: SharedAxisPageTransitionsBuilder(
@@ -15,6 +39,7 @@ class AppTheme extends ThemeExtension<AppTheme> {
         ),
       );
 
+
   @override
   ThemeExtension<AppTheme> copyWith() {
     // TODO: implement copyWith
@@ -22,8 +47,8 @@ class AppTheme extends ThemeExtension<AppTheme> {
   }
 
   @override
-  ThemeExtension<AppTheme> lerp(
-      covariant ThemeExtension<AppTheme>? other, double t) {
+  ThemeExtension<AppTheme> lerp(covariant ThemeExtension<AppTheme>? other,
+      double t) {
     // TODO: implement lerp
     throw UnimplementedError();
   }

--- a/lib/presenter/themes/app_theme.dart
+++ b/lib/presenter/themes/app_theme.dart
@@ -1,32 +1,81 @@
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:untitled/presenter/colors/app_theme_colors.dart';
+import 'package:untitled/presenter/themes/app_theme_styles.dart';
 import 'package:untitled/presenter/themes/app_theme_typography.dart';
 import 'package:untitled/utils/font_family.dart';
 
-import 'app_theme_styles.dart';
-
 class AppTheme extends ThemeExtension<AppTheme> {
-
   final String name;
   final String fontFamily;
   final Brightness brightness;
-  // final AppThemeColors colors;
-  // final AppThemeTypography typography;
-  // final AppThemeStyles styles;
+  final AppThemeColors colors;
+  final AppThemeTypography typography;
+  final AppThemeStyles styles;
 
   AppTheme({
     required this.name,
     required this.brightness,
-    // required this.colors,
-    // this.styles = const AppThemeStyles(),
-    // this.typography = const AppThemeTypography(),
+    required this.colors,
+    this.styles = const AppThemeStyles(),
+    this.typography = const AppThemeTypography(),
     this.fontFamily = FontFamily.circularStd,
   });
 
+  ColorScheme get baseColorScheme => brightness == Brightness.light
+      ? const ColorScheme.light()
+      : const ColorScheme.dark();
 
-  ThemeData get themeData =>
-      ThemeData().copyWith(
+  ThemeData get themeData => ThemeData(
+        useMaterial3: false,
+        platform: TargetPlatform.iOS,
+        extensions: [this],
+        brightness: brightness,
+        scaffoldBackgroundColor: colors.scaffoldBackground,
+        hintColor: colors.onSurface,
+        appBarTheme: AppBarTheme(
+          backgroundColor: Colors.transparent,
+          foregroundColor: colors.textColor,
+        ),
+        textTheme: TextTheme(
+          displayLarge: typography.displayLarge,
+          displayMedium: typography.displayMedium,
+          displaySmall: typography.displaySmall,
+          headlineLarge: typography.headlineLarge,
+          headlineMedium: typography.headlineMedium,
+          headlineSmall: typography.headlineSmall,
+          titleLarge: typography.titleLarge,
+          titleMedium: typography.titleMedium,
+          titleSmall: typography.titleSmall,
+          bodyLarge: typography.bodyLarge,
+          bodyMedium: typography.bodyMedium,
+          bodySmall: typography.bodySmall,
+          labelLarge: typography.labelLarge,
+          labelMedium: typography.labelMedium,
+          labelSmall: typography.labelSmall,
+        ),
+        searchBarTheme: SearchBarThemeData(
+          backgroundColor: WidgetStateProperty.all(colors.searchBarColor),
+        ),
+        tabBarTheme: TabBarTheme(
+          labelColor: colors.tabBarColor,
+          unselectedLabelColor: colors.onSurface.withOpacity(0.6),
+        ),
+        buttonTheme: ButtonThemeData(
+          buttonColor: colors.buttonColor,
+          textTheme: ButtonTextTheme.primary,
+        ),
+        iconTheme: IconThemeData(
+          color: colors.buttonIconColor,
+        ),
+        colorScheme: baseColorScheme.copyWith(
+          onPrimary: colors.onPrimary,
+          secondary: colors.onSecondary,
+          error: colors.error,
+          surface: colors.surface,
+          onError: colors.onError,
+          onSurface: colors.onSurface,
+        ),
         pageTransitionsTheme: const PageTransitionsTheme(
           builders: <TargetPlatform, PageTransitionsBuilder>{
             TargetPlatform.android: SharedAxisPageTransitionsBuilder(
@@ -37,19 +86,40 @@ class AppTheme extends ThemeExtension<AppTheme> {
             ),
           },
         ),
+        fontFamily: fontFamily,
       );
 
-
   @override
-  ThemeExtension<AppTheme> copyWith() {
-    // TODO: implement copyWith
-    throw UnimplementedError();
+  AppTheme copyWith({
+    String? name,
+    Brightness? brightness,
+    AppThemeColors? colors,
+    AppThemeTypography? typography,
+    AppThemeStyles? styles,
+    String? fontFamily,
+  }) {
+    return AppTheme(
+      name: name ?? this.name,
+      brightness: brightness ?? this.brightness,
+      colors: colors ?? this.colors,
+      typography: typography ?? this.typography,
+      styles: styles ?? this.styles,
+      fontFamily: fontFamily ?? this.fontFamily,
+    );
   }
 
   @override
-  ThemeExtension<AppTheme> lerp(covariant ThemeExtension<AppTheme>? other,
-      double t) {
-    // TODO: implement lerp
-    throw UnimplementedError();
+  AppTheme lerp(covariant ThemeExtension<AppTheme>? other, double t) {
+    if (other is! AppTheme) {
+      return this;
+    }
+    return AppTheme(
+      name: name,
+      brightness: brightness,
+      colors: colors.lerp(other.colors, t),
+      typography: typography.lerp(other.typography, t),
+      styles: styles,
+      fontFamily: fontFamily,
+    );
   }
 }

--- a/lib/presenter/themes/app_theme_styles.dart
+++ b/lib/presenter/themes/app_theme_styles.dart
@@ -1,0 +1,3 @@
+class AppThemeStyles {
+  const AppThemeStyles();
+}

--- a/lib/presenter/themes/app_theme_typography.dart
+++ b/lib/presenter/themes/app_theme_typography.dart
@@ -1,3 +1,73 @@
+import 'package:flutter/material.dart';
+
 class AppThemeTypography {
-  const AppThemeTypography();
+  final TextStyle displayLarge;
+  final TextStyle displayMedium;
+  final TextStyle displaySmall;
+  final TextStyle headlineLarge;
+  final TextStyle headlineMedium;
+  final TextStyle headlineSmall;
+  final TextStyle titleLarge;
+  final TextStyle titleMedium;
+  final TextStyle titleSmall;
+  final TextStyle bodyLarge;
+  final TextStyle bodyMedium;
+  final TextStyle bodySmall;
+  final TextStyle labelLarge;
+  final TextStyle labelMedium;
+  final TextStyle labelSmall;
+
+  const AppThemeTypography({
+    // 커스터마이징이 필요할 경우 사용하기 위해 직접 설정
+    this.displayLarge =
+        const TextStyle(fontSize: 57, fontWeight: FontWeight.w400),
+    this.displayMedium =
+        const TextStyle(fontSize: 45, fontWeight: FontWeight.w400),
+    this.displaySmall =
+        const TextStyle(fontSize: 36, fontWeight: FontWeight.w400),
+    this.headlineLarge =
+        const TextStyle(fontSize: 32, fontWeight: FontWeight.w400),
+    this.headlineMedium =
+        const TextStyle(fontSize: 28, fontWeight: FontWeight.w400),
+    this.headlineSmall =
+        const TextStyle(fontSize: 24, fontWeight: FontWeight.w400),
+    this.titleLarge =
+        const TextStyle(fontSize: 22, fontWeight: FontWeight.w500),
+    this.titleMedium =
+        const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+    this.titleSmall =
+        const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+    this.bodyLarge = const TextStyle(fontSize: 16, fontWeight: FontWeight.w400),
+    this.bodyMedium =
+        const TextStyle(fontSize: 14, fontWeight: FontWeight.w400),
+    this.bodySmall = const TextStyle(fontSize: 12, fontWeight: FontWeight.w400),
+    this.labelLarge =
+        const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+    this.labelMedium =
+        const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
+    this.labelSmall =
+        const TextStyle(fontSize: 11, fontWeight: FontWeight.w500),
+  });
+
+  AppThemeTypography lerp(covariant dynamic other, double t) {
+    if (other is! AppThemeTypography) return this;
+
+    return AppThemeTypography(
+      displayLarge: TextStyle.lerp(displayLarge, other.displayLarge, t)!,
+      displayMedium: TextStyle.lerp(displayMedium, other.displayMedium, t)!,
+      displaySmall: TextStyle.lerp(displaySmall, other.displaySmall, t)!,
+      headlineLarge: TextStyle.lerp(headlineLarge, other.headlineLarge, t)!,
+      headlineMedium: TextStyle.lerp(headlineMedium, other.headlineMedium, t)!,
+      headlineSmall: TextStyle.lerp(headlineSmall, other.headlineSmall, t)!,
+      titleLarge: TextStyle.lerp(titleLarge, other.titleLarge, t)!,
+      titleMedium: TextStyle.lerp(titleMedium, other.titleMedium, t)!,
+      titleSmall: TextStyle.lerp(titleSmall, other.titleSmall, t)!,
+      bodyLarge: TextStyle.lerp(bodyLarge, other.bodyLarge, t)!,
+      bodyMedium: TextStyle.lerp(bodyMedium, other.bodyMedium, t)!,
+      bodySmall: TextStyle.lerp(bodySmall, other.bodySmall, t)!,
+      labelLarge: TextStyle.lerp(labelLarge, other.labelLarge, t)!,
+      labelMedium: TextStyle.lerp(labelMedium, other.labelMedium, t)!,
+      labelSmall: TextStyle.lerp(labelSmall, other.labelSmall, t)!,
+    );
+  }
 }

--- a/lib/presenter/themes/app_theme_typography.dart
+++ b/lib/presenter/themes/app_theme_typography.dart
@@ -1,0 +1,3 @@
+class AppThemeTypography {
+  const AppThemeTypography();
+}

--- a/lib/presenter/themes/mode/app_theme_type.dart
+++ b/lib/presenter/themes/mode/app_theme_type.dart
@@ -1,0 +1,4 @@
+enum AppThemeType {
+  light,
+  dark,
+}

--- a/lib/presenter/themes/mode/dark_app_theme.dart
+++ b/lib/presenter/themes/mode/dark_app_theme.dart
@@ -1,29 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:untitled/presenter/colors/app_theme_colors.dart';
 import 'package:untitled/presenter/themes/app_theme.dart';
+import 'package:untitled/presenter/themes/app_theme_styles.dart';
+import 'package:untitled/presenter/themes/mode/app_theme_type.dart';
 
 class DarkAppTheme extends AppTheme {
   DarkAppTheme()
       : super(
-          name: 'dark',
+          name: AppThemeType.dark.name,
           brightness: Brightness.dark,
+          colors: AppThemeColors.fromAppColors(isDarkMode: true),
+          styles: const AppThemeStyles(),
         );
-
-  // DarkAppTheme()
-  //     : super(
-  //   name: 'dark',
-  //   brightness: Brightness.dark,
-  //   colors: AppThemeColors.fromAppColors(isDarkMode: true),
-  //   styles: const AppThemeStyles(
-  //     cardShadow: [
-  //       BoxShadow(
-  //         color: Color(0x4D000000),
-  //         offset: Offset(0, 2),
-  //         blurRadius: 4,
-  //       ),
-  //     ],
-  //   ),
-  // );
-
-  @override
-  ThemeData get themeData => super.themeData.copyWith();
 }

--- a/lib/presenter/themes/mode/dark_app_theme.dart
+++ b/lib/presenter/themes/mode/dark_app_theme.dart
@@ -2,8 +2,28 @@ import 'package:flutter/material.dart';
 import 'package:untitled/presenter/themes/app_theme.dart';
 
 class DarkAppTheme extends AppTheme {
+  DarkAppTheme()
+      : super(
+          name: 'dark',
+          brightness: Brightness.dark,
+        );
+
+  // DarkAppTheme()
+  //     : super(
+  //   name: 'dark',
+  //   brightness: Brightness.dark,
+  //   colors: AppThemeColors.fromAppColors(isDarkMode: true),
+  //   styles: const AppThemeStyles(
+  //     cardShadow: [
+  //       BoxShadow(
+  //         color: Color(0x4D000000),
+  //         offset: Offset(0, 2),
+  //         blurRadius: 4,
+  //       ),
+  //     ],
+  //   ),
+  // );
+
   @override
-  ThemeData get themeData => super.themeData.copyWith(
-        brightness: Brightness.dark,
-      );
+  ThemeData get themeData => super.themeData.copyWith();
 }

--- a/lib/presenter/themes/mode/light_app_theme.dart
+++ b/lib/presenter/themes/mode/light_app_theme.dart
@@ -2,8 +2,27 @@ import 'package:flutter/material.dart';
 import 'package:untitled/presenter/themes/app_theme.dart';
 
 class LightAppTheme extends AppTheme {
+  LightAppTheme() : super(
+          name: 'light',
+          brightness: Brightness.light,
+        );
+
+  // LightAppTheme()
+  //     : super(
+  //   name : 'light',
+  //   brightness: Brightness.light,
+  //   colors: AppThemeColors.fromAppColors(isDarkMode: false),
+  //   styles: const AppThemeStyles(
+  //     cardShadow: [
+  //       BoxShadow(
+  //         color: Color(0x29000000),
+  //         offset: Offset(0, 2),
+  //         blurRadius: 4,
+  //       ),
+  //     ],
+  //   ),
+  // );
+
   @override
-  ThemeData get themeData => super.themeData.copyWith(
-        brightness: Brightness.light,
-      );
+  ThemeData get themeData => super.themeData.copyWith();
 }

--- a/lib/presenter/themes/mode/light_app_theme.dart
+++ b/lib/presenter/themes/mode/light_app_theme.dart
@@ -1,28 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:untitled/presenter/colors/app_theme_colors.dart';
 import 'package:untitled/presenter/themes/app_theme.dart';
+import 'package:untitled/presenter/themes/app_theme_styles.dart';
+import 'package:untitled/presenter/themes/mode/app_theme_type.dart';
 
 class LightAppTheme extends AppTheme {
-  LightAppTheme() : super(
-          name: 'light',
+  LightAppTheme()
+      : super(
+          name: AppThemeType.light.name,
           brightness: Brightness.light,
+          colors: AppThemeColors.fromAppColors(isDarkMode: false),
+          styles: const AppThemeStyles(),
         );
-
-  // LightAppTheme()
-  //     : super(
-  //   name : 'light',
-  //   brightness: Brightness.light,
-  //   colors: AppThemeColors.fromAppColors(isDarkMode: false),
-  //   styles: const AppThemeStyles(
-  //     cardShadow: [
-  //       BoxShadow(
-  //         color: Color(0x29000000),
-  //         offset: Offset(0, 2),
-  //         blurRadius: 4,
-  //       ),
-  //     ],
-  //   ),
-  // );
-
-  @override
-  ThemeData get themeData => super.themeData.copyWith();
 }

--- a/lib/provider/theme_provider.dart
+++ b/lib/provider/theme_provider.dart
@@ -19,4 +19,13 @@ class ThemeProvider extends ChangeNotifier {
 
     notifyListeners();
   }
+
+  void toggleThemeMode() {
+    if (_themeMode == ThemeMode.light) {
+      _themeMode = ThemeMode.dark;
+    } else {
+      _themeMode = ThemeMode.light;
+    }
+    notifyListeners();
+  }
 }

--- a/lib/utils/font_family.dart
+++ b/lib/utils/font_family.dart
@@ -1,0 +1,5 @@
+class FontFamily { // 클래스의 인스턴스가 필요하지 않고, 클래스 내부의 정적 멤버들만 사용하는 경우 자주 사용되는 패턴
+  FontFamily._();
+
+  static const String circularStd = 'CircularStd';
+}

--- a/lib/widgets/navigation.dart
+++ b/lib/widgets/navigation.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class Navigation extends StatelessWidget {
+  final int currentPageIndex;
+  final ValueChanged<int> onDestinationSelected;
+
+  const Navigation({
+    required this.currentPageIndex,
+    required this.onDestinationSelected,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+      destinations: const [
+        NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
+        NavigationDestination(icon: Icon(Icons.favorite), label: 'Like'),
+        NavigationDestination(icon: Icon(Icons.chat), label: 'Chat'),
+        NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
+      ],
+      selectedIndex: currentPageIndex,
+      onDestinationSelected: onDestinationSelected,
+    );
+  }
+}


### PR DESCRIPTION
**주요 변경 사항**

1. 다크 모드와 라이트 모드 테마 설정 추가
- AppColors 클래스에 라이트 모드 및 다크 모드 색상 정의 추가
- AppThemeColors 및 AppThemeTypography 클래스를 사용하여 테마 커스터마이징 기능 추가
- DarkAppTheme 및 LightAppTheme 클래스에 색상과 스타일 설정 추가
- ThemeProvider에 다크 모드와 라이트 모드 전환 기능 구현
- AppTheme 클래스에서 copyWith 및 lerp 메서드를 구현하여 테마 확장 가능

2. 기존 코드 리팩토링
- MainScreen, Home, Like, Chat, Settings 위젯을 개별 폴더(pages)로 이동
- Navigation 위젯을 widgets 폴더로 이동
- 새로운 폴더 구조에 맞게 import 경로 수정
- 불필요한 import 제거 및 코드 스타일 수정 (Lint 적용)

**추가 구현 및 향후 계획**
- 추후 커스텀 스타일 및 컬러 통합을 위한 기초 작업을 완료
- 현재 PR에서 추가된 테마 확장 기능을 활용하여 다양한 커스텀 테마를 추가할 예정

**테스트**
- 테마 전환 기능 동작 테스트 완료
- 페이지 이동 및 탭 전환시 애니메이션이 올바르게 적용되는지 테스트 완료