### PR TITLE
Feat/settings page UI implement : Settings 페이지 추가 및 UI 개선, 리팩토링

### DIFF
--- a/lib/presenter/pages/settings.dart
+++ b/lib/presenter/pages/settings.dart
@@ -1,24 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:untitled/presenter/themes/app_theme.dart';
 import 'package:untitled/presenter/widgets/card_layout.dart';
 import 'package:untitled/presenter/widgets/settings/settings_tile.dart';
+import 'package:untitled/utils/constants.dart';
 
 class Settings extends StatelessWidget {
   const Settings({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final appTheme = Theme.of(context).extension<AppTheme>()!;
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
+        title: Text(
           'Settings',
-          style: TextStyle(color: Colors.black),
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+            color: appTheme.colors.textColor,
+          ),
         ),
         elevation: 0,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       ),
       body: SingleChildScrollView(
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
+          padding: AppPadding.kContentPadding,
           child: Column(
             children: [
               CardLayout(
@@ -42,9 +47,7 @@ class Settings extends StatelessWidget {
                   ),
                 ],
               ),
-              const SizedBox(
-                height: 16.0,
-              ),
+              Spacing.mediumHeight(),
               CardLayout(
                 backgroundColor: Theme.of(context).cardColor,
                 children: [
@@ -76,9 +79,7 @@ class Settings extends StatelessWidget {
                   ),
                 ],
               ),
-              const SizedBox(
-                height: 16.0,
-              ),
+              Spacing.mediumHeight(),
               CardLayout(
                 backgroundColor: Theme.of(context).cardColor,
                 children: [

--- a/lib/presenter/pages/settings.dart
+++ b/lib/presenter/pages/settings.dart
@@ -1,21 +1,97 @@
 import 'package:flutter/material.dart';
+import 'package:untitled/presenter/widgets/card_layout.dart';
+import 'package:untitled/presenter/widgets/settings/settings_tile.dart';
 
 class Settings extends StatelessWidget {
   const Settings({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.settings, size: 100, color: Colors.grey),
-          SizedBox(height: 20),
-          Text(
-            'App Settings',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Settings',
+          style: TextStyle(color: Colors.black),
+        ),
+        elevation: 0,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
+          child: Column(
+            children: [
+              CardLayout(
+                backgroundColor: Theme.of(context).cardColor,
+                children: [
+                  SettingsTile(
+                    icon: Icons.person,
+                    title: 'Profile Settings',
+                    subtitle: 'Edit your profile',
+                    onTap: () {},
+                  ),
+                  SettingsTile(
+                    icon: Icons.color_lens,
+                    title: 'Theme',
+                    onTap: () {},
+                  ),
+                  SettingsTile(
+                    icon: Icons.language,
+                    title: 'Language',
+                    onTap: () {},
+                  ),
+                ],
+              ),
+              const SizedBox(
+                height: 16.0,
+              ),
+              CardLayout(
+                backgroundColor: Theme.of(context).cardColor,
+                children: [
+                  SettingsTile(
+                    icon: Icons.info_outline,
+                    title: 'About Us',
+                    onTap: () {},
+                  ),
+                  SettingsTile(
+                    icon: Icons.contact_support,
+                    title: 'Contact Support',
+                    onTap: () {},
+                  ),
+                  SettingsTile(
+                    icon: Icons.feedback,
+                    title: 'Feedback',
+                    onTap: () {},
+                  ),
+                  SettingsTile(
+                    icon: Icons.security,
+                    title: 'Security',
+                    subtitle: 'Manage security settings',
+                    onTap: () {},
+                  ),
+                  SettingsTile(
+                    icon: Icons.info,
+                    title: 'Version Info',
+                    onTap: () {},
+                  ),
+                ],
+              ),
+              const SizedBox(
+                height: 16.0,
+              ),
+              CardLayout(
+                backgroundColor: Theme.of(context).cardColor,
+                children: [
+                  SettingsTile(
+                    icon: Icons.logout_rounded,
+                    title: 'Logout',
+                    onTap: () {},
+                  ),
+                ],
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/presenter/pages/settings.dart
+++ b/lib/presenter/pages/settings.dart
@@ -14,12 +14,9 @@ class Settings extends StatelessWidget {
       appBar: AppBar(
         title: Text(
           'Settings',
-          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-            color: appTheme.colors.textColor,
-          ),
+          style: appTheme.typographies.headlineSmall
         ),
         elevation: 0,
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       ),
       body: SingleChildScrollView(
         child: Padding(

--- a/lib/presenter/widgets/card_layout.dart
+++ b/lib/presenter/widgets/card_layout.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:untitled/utils/constants.dart';
 
 class CardLayout extends StatelessWidget {
   final Widget? title;
@@ -11,7 +12,7 @@ class CardLayout extends StatelessWidget {
   const CardLayout({
     required this.children,
     this.title,
-    this.titleSpacing = 16.0,
+    this.titleSpacing = AppDimensions.medium,
     super.key,
     this.padding = const EdgeInsets.all(12),
     this.backgroundColor = Colors.white,

--- a/lib/presenter/widgets/home/home_tab_bar_delegate.dart
+++ b/lib/presenter/widgets/home/home_tab_bar_delegate.dart
@@ -16,6 +16,7 @@ class HomeTabBarDelegate extends SliverPersistentHeaderDelegate {
     bool overlapsContent,
   ) {
     return Container(
+      color: Theme.of(context).scaffoldBackgroundColor,
       padding: AppPadding.kVerticalSmallPadding,
       child: TabBar(
         padding: AppPadding.kHorizontalPadding,

--- a/lib/presenter/widgets/settings/settings_tile.dart
+++ b/lib/presenter/widgets/settings/settings_tile.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class SettingsTile extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final VoidCallback? onTap;
+
+  const SettingsTile({
+    required this.icon,
+    required this.title,
+    super.key,
+    this.subtitle,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(
+        icon,
+        color: Theme.of(context).colorScheme.primary,
+      ),
+      title: Text(
+        title,
+        style: Theme.of(context).textTheme.bodyLarge,
+      ),
+      subtitle: subtitle != null
+          ? Text(
+        subtitle!,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: Theme.of(context).hintColor,
+        ),
+      )
+          : null,
+      trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/presenter/widgets/settings/settings_tile.dart
+++ b/lib/presenter/widgets/settings/settings_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:untitled/presenter/themes/app_theme.dart';
 
 class SettingsTile extends StatelessWidget {
   final IconData icon;
@@ -16,25 +17,31 @@ class SettingsTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      leading: Icon(
-        icon,
-        color: Theme.of(context).colorScheme.primary,
-      ),
-      title: Text(
-        title,
-        style: Theme.of(context).textTheme.bodyLarge,
-      ),
-      subtitle: subtitle != null
-          ? Text(
-        subtitle!,
-        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-          color: Theme.of(context).hintColor,
+    final appTheme = Theme.of(context).extension<AppTheme>()!;
+    return Material(
+      color: Colors.transparent,
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        splashFactory: NoSplash.splashFactory,
+        onTap: onTap,
+        child: ListTile(
+          leading: Icon(
+            icon,
+            color: appTheme.colors.textColor,
+          ),
+          title: Text(
+            title,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: appTheme.colors.textColor,
+                ),
+          ),
+          subtitle: subtitle != null
+              ? Text(subtitle!, style: appTheme.typographies.bodySmall)
+              : null,
+          trailing: const Icon(Icons.arrow_forward_ios, size: 16),
         ),
-      )
-          : null,
-      trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-      onTap: onTap,
+      ),
     );
   }
 }

--- a/lib/presenter/widgets/stock_detail/stock_detail_flexible_space_bar.dart
+++ b/lib/presenter/widgets/stock_detail/stock_detail_flexible_space_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:untitled/utils/constants.dart';
 
 Widget StockDetailFlexibleSpaceBar(context) {
   return FlexibleSpaceBar(
@@ -24,12 +25,11 @@ Widget StockDetailFlexibleSpaceBar(context) {
                         Text(
                           "Apple",
                           style: TextStyle(
-                            color: Theme.of(context).colorScheme.primary,
                             fontSize: 24,
                             fontWeight: FontWeight.w500,
                           ),
                         ),
-                        const SizedBox(height: 4),
+                        Spacing.height(4.0),
                         RichText(
                           text: TextSpan(
                             children: [
@@ -57,7 +57,7 @@ Widget StockDetailFlexibleSpaceBar(context) {
                             ],
                           ),
                         ),
-                        SizedBox(height: 4),
+                        Spacing.height(4.0),
                         Text(
                           "capital at risk",
                           style: TextStyle(
@@ -87,8 +87,8 @@ Widget StockDetailFlexibleSpaceBar(context) {
               ),
             ],
           ),
-          SizedBox(height: 16),
-          Container(
+          Spacing.mediumHeight(),
+          Padding(
             padding: const EdgeInsets.symmetric(
               horizontal: 8,
             ),
@@ -133,12 +133,12 @@ Widget StockDetailFlexibleSpaceBar(context) {
                   onPressed: () {},
                   style: ButtonStyle(
                     backgroundColor:
-                    MaterialStateProperty.resolveWith(
+                    WidgetStateProperty.resolveWith(
                           (states) {
                         return Colors.grey[200];
                       },
                     ),
-                    padding: MaterialStateProperty.resolveWith(
+                    padding: WidgetStateProperty.resolveWith(
                           (states) {
                         return const EdgeInsets.symmetric(
                           vertical: 8,
@@ -146,7 +146,7 @@ Widget StockDetailFlexibleSpaceBar(context) {
                         );
                       },
                     ),
-                    shape: MaterialStateProperty.resolveWith(
+                    shape: WidgetStateProperty.resolveWith(
                           (states) {
                         return RoundedRectangleBorder(
                           borderRadius:

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -9,10 +9,10 @@ abstract class AppDimensions {
 }
 
 abstract class AppPadding {
-  static const EdgeInsets kHorizontalPadding = EdgeInsets.symmetric(horizontal: 16.0);
-  static const EdgeInsets kVerticalSmallPadding = EdgeInsets.symmetric(vertical: 8.0);
-  static const EdgeInsets kLeftPadding = EdgeInsets.only(left: 16.0);
-  static const EdgeInsets kContentPadding = EdgeInsets.all(16.0);
+  static const EdgeInsets kHorizontalPadding = EdgeInsets.symmetric(horizontal: AppDimensions.medium);
+  static const EdgeInsets kVerticalSmallPadding = EdgeInsets.symmetric(vertical: AppDimensions.small);
+  static const EdgeInsets kLeftPadding = EdgeInsets.only(left: AppDimensions.medium);
+  static const EdgeInsets kContentPadding = EdgeInsets.all(AppDimensions.medium);
 
   static EdgeInsets smallPadding() => const EdgeInsets.all(AppDimensions.small);
   static EdgeInsets mediumPadding() => const EdgeInsets.all(AppDimensions.medium);
@@ -20,7 +20,7 @@ abstract class AppPadding {
 }
 
 abstract class AppSizes {
-  static const Size kAppBarHeight = Size.fromHeight(56.0);
+  static const Size kAppBarHeight = Size.fromHeight(AppDimensions.appBarHeight);
 }
 
 abstract class Spacing {


### PR DESCRIPTION
<p align="center">
  <img src="https://github.com/user-attachments/assets/478bea43-d0d1-4263-b639-9694d546a4e5" alt="Screenshot 1" width="45%"/>
  <img src="https://github.com/user-attachments/assets/da8ba532-a0bd-4ed9-8655-f8a2c091952c" alt="Screenshot 2" width="45%"/>
</p>


1. **Settings 페이지 UI 구현**:
   - `SettingsTile` 위젯을 추가해서 각 설정 항목에 아이콘, 제목, 부제목, 클릭 이벤트 등을 지원
   - `CardLayout`을 사용해 설정 항목을 그룹화하고, 페이지 디자인을 좀 더 체계적으로 변경

2. **CardLayout 및 SettingsTile 리팩토링**:
   - `AppPadding`과 `Spacing` 유틸리티를 적용해서 `CardLayout`과 `SettingsTile`에서 코드의 일관성을 유지
   - `SettingsTile`에서 `AppTheme`을 사용해 스타일을 통일되게 적용하고, InkWell의 잉크 스플래시 효과를 제거해서 더 깔끔한 UI/UX를 구현
   - `Settings` 화면에서 `Spacing`과 `AppPadding`을 활용해 간격 및 패딩을 개선
   - `AppDimensions` 및 `AppPadding` 유틸리티를 추가해서 UI 크기와 간격을 쉽게 관리할 수 있게 수정