### PR TITLE
Feat/theme mode improve

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,8 +26,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
-    return
-      MaterialApp(
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Untitled',
       themeMode: themeProvider.themeMode,

--- a/lib/presenter/core/exceptions.dart
+++ b/lib/presenter/core/exceptions.dart
@@ -1,3 +1,14 @@
 class ServerException implements Exception {}
 
 class CacheException implements Exception {}
+
+class ThemeProviderException implements Exception {
+  final String message;
+
+  ThemeProviderException(this.message);
+
+  @override
+  String toString() {
+    return 'ThemeProviderException: $message';
+  }
+}

--- a/lib/presenter/widgets/home/home_appbar.dart
+++ b/lib/presenter/widgets/home/home_appbar.dart
@@ -28,7 +28,6 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
         ),
       ),
       title: ThemeSwitcherButton(
-        isDarkTheme: themeProvider.isDarkMode,
         onPressed: () => themeProvider.toggleThemeMode(),
       ),
       actions: [

--- a/lib/presenter/widgets/theme_switcher_button.dart
+++ b/lib/presenter/widgets/theme_switcher_button.dart
@@ -1,23 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:untitled/provider/theme_provider.dart';
 
 class ThemeSwitcherButton extends StatelessWidget {
   static const IconData _lightThemeIcon = Icons.wb_sunny_outlined;
   static const IconData _darkThemeIcon = Icons.dark_mode_outlined;
 
-  final bool isDarkTheme;
   final VoidCallback onPressed;
 
   const ThemeSwitcherButton({
-    required this.isDarkTheme,
     required this.onPressed,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
+    final themeProvider = Provider.of<ThemeProvider>(context);
     return IconButton(
       onPressed: onPressed,
-      icon: Icon(isDarkTheme ? _darkThemeIcon : _lightThemeIcon),
+      icon: Icon(
+        ThemeMode.dark == themeProvider.themeMode
+            ? _darkThemeIcon
+            : _lightThemeIcon,
+      ),
       iconSize: 25,
       constraints: const BoxConstraints(),
       splashRadius: 20,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   provider: ^6.1.2
   animations: ^2.0.11
   flutter_svg: ^2.0.10+1
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Feat: SharedPreferences를 사용한 테마 모드 저장 및 예외 처리 추가

### 개요
앱에서 선택한 테마 모드를 로컬에 저장하고, 재실행 시 저장된 테마 모드를 불러오는 기능 추가 및 예외 처리 강화

### 주요 변경 사항
- **SharedPreferences 의존성 추가**: 테마 모드 저장을 위해 SharedPreferences 의존성 추가
- **테마 모드 저장 및 불러오기 기능 구현**: SharedPreferences를 이용해 테마 모드를 저장하고 불러오는 로직 추가
- **예외 처리 추가**: SharedPreferences 초기화 및 저장/불러오기 시 발생할 수 있는 예외를 처리하기 위해 `ThemeProviderException` 추가

### 테스트
- 테마 모드 저장 후 앱 재실행 시에도 테마 모드가 유지되는지 테스트 완료
- SharedPreferences 초기화 실패 및 예외 상황에서 에러 처리되는지 확인 필요