### PR TITLE
Feat/dark mode UI : 다크 모드 및 라이트 모드 테마 리팩토링 및 네비게이션 UX 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 ios/Flutter/Flutter.framework
 ios/Flutter/Flutter.podspec
 ios/Pods/
+ios/Podfile

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/lib/presenter/navigation/navigation.dart
+++ b/lib/presenter/navigation/navigation.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:untitled/provider/theme_provider.dart';
 
 class Navigation extends StatelessWidget {
   final int currentPageIndex;
@@ -12,15 +14,79 @@ class Navigation extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return NavigationBar(
-      destinations: const [
-        NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
-        NavigationDestination(icon: Icon(Icons.favorite), label: 'Like'),
-        NavigationDestination(icon: Icon(Icons.chat), label: 'Chat'),
-        NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
-      ],
-      selectedIndex: currentPageIndex,
-      onDestinationSelected: onDestinationSelected,
+    final themeMode = Provider.of<ThemeProvider>(context).themeMode;
+
+    Color lightSelectedColor = const Color(0xFF2d65e4);
+    Color lightUnselectedColor = const Color(0xFF777e89);
+    Color lightBackgroundColor = const Color(0xFFf8f8f8);
+
+    Color darkSelectedColor = const Color(0xFF3981f6);
+    Color darkUnselectedColor = const Color(0xFF909090);
+    Color darkBackgroundColor = const Color(0xFF141414);
+
+    Color selectedColor =
+        themeMode == ThemeMode.dark ? darkSelectedColor : lightSelectedColor;
+    Color unselectedColor = themeMode == ThemeMode.dark
+        ? darkUnselectedColor
+        : lightUnselectedColor;
+    Color backgroundColor = themeMode == ThemeMode.dark
+        ? darkBackgroundColor
+        : lightBackgroundColor;
+
+    return Container(
+      decoration: BoxDecoration(
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.withOpacity(0.5),
+            spreadRadius: 0,
+            blurRadius: 0.1,
+          ),
+        ],
+      ),
+      child: NavigationBarTheme(
+        data: NavigationBarThemeData(
+          height: 60,
+          backgroundColor: backgroundColor,
+          labelTextStyle: WidgetStateProperty.resolveWith<TextStyle?>(
+            (Set<WidgetState> states) {
+              if (states.contains(WidgetState.selected)) {
+                return TextStyle(
+                  color: selectedColor,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 11,
+                );
+              }
+              return TextStyle(color: unselectedColor, fontSize: 11);
+            },
+          ),
+        ),
+        child: NavigationBar(
+          selectedIndex: currentPageIndex,
+          onDestinationSelected: onDestinationSelected,
+          destinations: <NavigationDestination>[
+            NavigationDestination(
+              icon: Icon(Icons.home, color: unselectedColor),
+              selectedIcon: Icon(Icons.home, color: selectedColor),
+              label: 'Home',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.favorite, color: unselectedColor),
+              selectedIcon: Icon(Icons.favorite, color: selectedColor),
+              label: 'Like',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.chat, color: unselectedColor),
+              selectedIcon: Icon(Icons.chat, color: selectedColor),
+              label: 'Chat',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.settings, color: unselectedColor),
+              selectedIcon: Icon(Icons.settings, color: selectedColor),
+              label: 'Settings',
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/presenter/navigation/navigation.dart
+++ b/lib/presenter/navigation/navigation.dart
@@ -61,6 +61,11 @@ class Navigation extends StatelessWidget {
           ),
         ),
         child: NavigationBar(
+          animationDuration: const Duration(milliseconds: 1200),
+          overlayColor: WidgetStateProperty.all(Colors.transparent),
+          indicatorShape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20.0),
+          ),
           selectedIndex: currentPageIndex,
           onDestinationSelected: onDestinationSelected,
           destinations: <NavigationDestination>[

--- a/lib/presenter/pages/accounts.dart
+++ b/lib/presenter/pages/accounts.dart
@@ -26,6 +26,8 @@ class AccountsWidget extends StatelessWidget {
           ),
           Spacing.largeHeight(),
           TradeHistoryCard(tradeHistory: tradeHistory),
+          Spacing.largeHeight(),
+          TradeHistoryCard(tradeHistory: tradeHistory),
           Spacing.extraLargeHeight(),
         ],
       ),

--- a/lib/presenter/pages/settings.dart
+++ b/lib/presenter/pages/settings.dart
@@ -24,7 +24,6 @@ class Settings extends StatelessWidget {
           child: Column(
             children: [
               CardLayout(
-                backgroundColor: Theme.of(context).cardColor,
                 children: [
                   SettingsTile(
                     icon: Icons.person,
@@ -46,7 +45,6 @@ class Settings extends StatelessWidget {
               ),
               Spacing.mediumHeight(),
               CardLayout(
-                backgroundColor: Theme.of(context).cardColor,
                 children: [
                   SettingsTile(
                     icon: Icons.info_outline,
@@ -78,7 +76,6 @@ class Settings extends StatelessWidget {
               ),
               Spacing.mediumHeight(),
               CardLayout(
-                backgroundColor: Theme.of(context).cardColor,
                 children: [
                   SettingsTile(
                     icon: Icons.logout_rounded,

--- a/lib/presenter/themes/app_theme.dart
+++ b/lib/presenter/themes/app_theme.dart
@@ -56,6 +56,16 @@ class AppTheme extends ThemeExtension<AppTheme> {
           labelMedium: typographies.labelMedium,
           labelSmall: typographies.labelSmall,
         ),
+        cardTheme: CardTheme(
+          color: colors.cardBackground,
+          shadowColor: colors.cardShadowColor,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+          elevation: 0.2,
+          clipBehavior: Clip.antiAlias,
+          surfaceTintColor: Colors.transparent,
+        ),
         inputDecorationTheme: InputDecorationTheme(
           contentPadding:
               const EdgeInsets.symmetric(vertical: 8, horizontal: 42),
@@ -73,11 +83,11 @@ class AppTheme extends ThemeExtension<AppTheme> {
           suffixIconColor: colors.onSurface,
         ),
         tabBarTheme: TabBarTheme(
-          labelColor: colors.onSurface,
+          labelColor: colors.textColor,
           unselectedLabelColor: AppColors.darkGrey,
           indicator: BoxDecoration(
             borderRadius: BorderRadius.circular(100),
-            color: colors.onPrimary,
+            color: colors.tabBarColor,
           ),
           labelPadding: const EdgeInsets.symmetric(horizontal: 4),
           indicatorSize: TabBarIndicatorSize.label,

--- a/lib/presenter/themes/colors/app_colors.dart
+++ b/lib/presenter/themes/colors/app_colors.dart
@@ -13,6 +13,14 @@ abstract class AppColors {
   static const Color lightTitleColor = Color(0xFF707070);
   static const Color lightPrimary = Color(0xFF4478E2);
 
+  static const Color lightSurface = Color(0xFFFFFFFF);
+  static const Color lightError = Color(0xFFB00020);
+  static const Color lightOnPrimary = Color(0xFFFFFFFF);
+  static const Color lightOnSecondary = Color(0xFF000000);
+  static const Color lightOnBackground = Color(0xFF000000);
+  static const Color lightOnSurface = Color(0xFF000000);
+  static const Color lightOnError = Color(0xFFFFFFFF);
+
   // DarkMode
   static const Color darkScaffoldBackground = Color(0xFF000000);
   static const Color darkCardBackground = Color(0xFF161616);
@@ -23,6 +31,14 @@ abstract class AppColors {
   static const Color darkButtonIconColor = Color(0xFF3783f9);
   static const Color darkTextColor = Color(0xFFf7f7f7);
   static const Color darkTitleColor = Color(0xFFC0C0C0);
+
+  static const Color darkSurface = Color(0xFF121212);
+  static const Color darkError = Color(0xFFCF6679);
+  static const Color darkOnPrimary = Color(0xFF000000);
+  static const Color darkOnSecondary = Color(0xFFFFFFFF);
+  static const Color darkOnBackground = Color(0xFFFFFFFF);
+  static const Color darkOnSurface = Color(0xFFFFFFFF);
+  static const Color darkOnError = Color(0xFF000000);
 
   static const Color surface = Color(0xFFFFFFFF);
   static const Color error = Color(0xFFB00020);

--- a/lib/presenter/themes/colors/app_colors.dart
+++ b/lib/presenter/themes/colors/app_colors.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 abstract class AppColors {
   // LightMode
   static const Color lightScaffoldBackground = Color(0xFFF7F7F7);
+  static const Color lightCardBackground = Color(0xFFFFFFFF);
+  static const Color lightCardShadowColor = Color(0xFFB0BEC5);
   static const Color lightSearchBarColor = Color(0xFFedeff3);
   static const Color lightTabBarColor = Color(0xFFD9D9D9);
   static const Color lightButtonColor = Color(0xFFE8F0FD);
@@ -12,12 +14,14 @@ abstract class AppColors {
   static const Color lightPrimary = Color(0xFF4478E2);
 
   // DarkMode
-  static const Color darkScaffoldBackground = Color(0xFF303030);
-  static const Color darkSearchBarColor = Color(0xFF424242);
-  static const Color darkTabBarColor = Color(0xFF424242);
-  static const Color darkButtonColor = Color(0xFF3D80DE);
-  static const Color darkButtonIconColor = Color(0xFFC5D9F4);
-  static const Color darkTextColor = Color(0xFFFFFFFF);
+  static const Color darkScaffoldBackground = Color(0xFF000000);
+  static const Color darkCardBackground = Color(0xFF161616);
+  static const Color darkCardShadowColor = Color(0xFFB0BEC5);
+  static const Color darkSearchBarColor = Color(0xFF232323);
+  static const Color darkTabBarColor = Color(0xFF161616);
+  static const Color darkButtonColor = Color(0xFF1a212e);
+  static const Color darkButtonIconColor = Color(0xFF3783f9);
+  static const Color darkTextColor = Color(0xFFf7f7f7);
   static const Color darkTitleColor = Color(0xFFC0C0C0);
 
   static const Color surface = Color(0xFFFFFFFF);

--- a/lib/presenter/themes/colors/app_theme_colors.dart
+++ b/lib/presenter/themes/colors/app_theme_colors.dart
@@ -42,50 +42,45 @@ class AppThemeColors {
   static AppThemeColors fromAppColors({
     required bool isDarkMode,
   }) {
-    final lightColors = {
-      'scaffoldBackground': AppColors.lightScaffoldBackground,
-      'cardBackground' : AppColors.lightCardBackground,
-      'cardShadowColor': AppColors.lightCardShadowColor,
-      'searchBarColor': AppColors.lightSearchBarColor,
-      'tabBarColor': AppColors.lightTabBarColor,
-      'buttonColor': AppColors.lightButtonColor,
-      'buttonIconColor': AppColors.lightButtonIconColor,
-      'textColor': AppColors.lightTextColor,
-      'titleColor': AppColors.lightTitleColor,
-    };
-
-    final darkColors = {
-      'scaffoldBackground': AppColors.darkScaffoldBackground,
-      'cardBackground' : AppColors.darkCardBackground,
-      'cardShadowColor': AppColors.darkCardShadowColor,
-      'searchBarColor': AppColors.darkSearchBarColor,
-      'tabBarColor': AppColors.darkTabBarColor,
-      'buttonColor': AppColors.darkButtonColor,
-      'buttonIconColor': AppColors.darkButtonIconColor,
-      'textColor': AppColors.darkTextColor,
-      'titleColor': AppColors.darkTitleColor,
-    };
-
-    final selectedColors = isDarkMode ? darkColors : lightColors;
-
-    return AppThemeColors(
-      scaffoldBackground: selectedColors['scaffoldBackground']!,
-      cardBackground: selectedColors['cardBackground']!,
-      cardShadowColor: selectedColors['cardShadowColor']!,
-      searchBarColor: selectedColors['searchBarColor']!,
-      tabBarColor: selectedColors['tabBarColor']!,
-      buttonColor: selectedColors['buttonColor']!,
-      buttonIconColor: selectedColors['buttonIconColor']!,
-      textColor: selectedColors['textColor']!,
-      titleColor: selectedColors['titleColor']!,
-      surface: AppColors.surface,
-      error: AppColors.error,
-      onPrimary: AppColors.onPrimary,
-      onSecondary: AppColors.onSecondary,
-      onBackground: AppColors.onBackground,
-      onSurface: AppColors.onSurface,
-      onError: AppColors.onError,
-    );
+    if (isDarkMode) {
+      return const AppThemeColors(
+        scaffoldBackground: AppColors.darkScaffoldBackground,
+        cardBackground: AppColors.darkCardBackground,
+        cardShadowColor: AppColors.darkCardShadowColor,
+        searchBarColor: AppColors.darkSearchBarColor,
+        tabBarColor: AppColors.darkTabBarColor,
+        buttonColor: AppColors.darkButtonColor,
+        buttonIconColor: AppColors.darkButtonIconColor,
+        textColor: AppColors.darkTextColor,
+        titleColor: AppColors.darkTitleColor,
+        surface: AppColors.darkSurface,
+        error: AppColors.darkError,
+        onPrimary: AppColors.darkOnPrimary,
+        onSecondary: AppColors.darkOnSecondary,
+        onBackground: AppColors.darkOnBackground,
+        onSurface: AppColors.darkOnSurface,
+        onError: AppColors.darkOnError,
+      );
+    } else {
+      return const AppThemeColors(
+        scaffoldBackground: AppColors.lightScaffoldBackground,
+        cardBackground: AppColors.lightCardBackground,
+        cardShadowColor: AppColors.lightCardShadowColor,
+        searchBarColor: AppColors.lightSearchBarColor,
+        tabBarColor: AppColors.lightTabBarColor,
+        buttonColor: AppColors.lightButtonColor,
+        buttonIconColor: AppColors.lightButtonIconColor,
+        textColor: AppColors.lightTextColor,
+        titleColor: AppColors.lightTitleColor,
+        surface: AppColors.lightSurface,
+        error: AppColors.lightError,
+        onPrimary: AppColors.lightOnPrimary,
+        onSecondary: AppColors.lightOnSecondary,
+        onBackground: AppColors.lightOnBackground,
+        onSurface: AppColors.lightOnSurface,
+        onError: AppColors.lightOnError,
+      );
+    }
   }
 
   AppThemeColors lerp(covariant dynamic other, double t) {
@@ -95,7 +90,7 @@ class AppThemeColors {
     return AppThemeColors(
       scaffoldBackground:
           Color.lerp(scaffoldBackground, other.scaffoldBackground, t)!,
-      cardBackground: Color.lerp(cardBackground, other.cardShadowColor, t)!,
+      cardBackground: Color.lerp(cardBackground, other.cardBackground, t)!,
       cardShadowColor: Color.lerp(cardShadowColor, other.cardShadowColor, t)!,
       searchBarColor: Color.lerp(searchBarColor, other.searchBarColor, t)!,
       tabBarColor: Color.lerp(tabBarColor, other.tabBarColor, t)!,

--- a/lib/presenter/themes/colors/app_theme_colors.dart
+++ b/lib/presenter/themes/colors/app_theme_colors.dart
@@ -4,6 +4,8 @@ import 'package:untitled/presenter/themes/colors/app_colors.dart';
 // [AppThemeColors] : AppColors에 정의된 색상들을 사용하여 테마에 필요한 색상 팔레트를 구성
 class AppThemeColors {
   final Color scaffoldBackground;
+  final Color cardBackground;
+  final Color cardShadowColor;
   final Color searchBarColor;
   final Color tabBarColor;
   final Color buttonColor;
@@ -20,6 +22,8 @@ class AppThemeColors {
 
   const AppThemeColors({
     required this.scaffoldBackground,
+    required this.cardBackground,
+    required this.cardShadowColor,
     required this.searchBarColor,
     required this.tabBarColor,
     required this.buttonColor,
@@ -40,6 +44,8 @@ class AppThemeColors {
   }) {
     final lightColors = {
       'scaffoldBackground': AppColors.lightScaffoldBackground,
+      'cardBackground' : AppColors.lightCardBackground,
+      'cardShadowColor': AppColors.lightCardShadowColor,
       'searchBarColor': AppColors.lightSearchBarColor,
       'tabBarColor': AppColors.lightTabBarColor,
       'buttonColor': AppColors.lightButtonColor,
@@ -50,6 +56,8 @@ class AppThemeColors {
 
     final darkColors = {
       'scaffoldBackground': AppColors.darkScaffoldBackground,
+      'cardBackground' : AppColors.darkCardBackground,
+      'cardShadowColor': AppColors.darkCardShadowColor,
       'searchBarColor': AppColors.darkSearchBarColor,
       'tabBarColor': AppColors.darkTabBarColor,
       'buttonColor': AppColors.darkButtonColor,
@@ -62,6 +70,8 @@ class AppThemeColors {
 
     return AppThemeColors(
       scaffoldBackground: selectedColors['scaffoldBackground']!,
+      cardBackground: selectedColors['cardBackground']!,
+      cardShadowColor: selectedColors['cardShadowColor']!,
       searchBarColor: selectedColors['searchBarColor']!,
       tabBarColor: selectedColors['tabBarColor']!,
       buttonColor: selectedColors['buttonColor']!,
@@ -85,6 +95,8 @@ class AppThemeColors {
     return AppThemeColors(
       scaffoldBackground:
           Color.lerp(scaffoldBackground, other.scaffoldBackground, t)!,
+      cardBackground: Color.lerp(cardBackground, other.cardShadowColor, t)!,
+      cardShadowColor: Color.lerp(cardShadowColor, other.cardShadowColor, t)!,
       searchBarColor: Color.lerp(searchBarColor, other.searchBarColor, t)!,
       tabBarColor: Color.lerp(tabBarColor, other.tabBarColor, t)!,
       buttonColor: Color.lerp(buttonColor, other.buttonColor, t)!,

--- a/lib/presenter/themes/mode/app_theme_type.dart
+++ b/lib/presenter/themes/mode/app_theme_type.dart
@@ -1,4 +1,0 @@
-enum AppThemeType {
-  light,
-  dark,
-}

--- a/lib/presenter/themes/mode/dark_app_theme.dart
+++ b/lib/presenter/themes/mode/dark_app_theme.dart
@@ -2,12 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:untitled/presenter/themes/app_theme.dart';
 import 'package:untitled/presenter/themes/app_theme_styles.dart';
 import 'package:untitled/presenter/themes/colors/app_theme_colors.dart';
-import 'package:untitled/presenter/themes/mode/app_theme_type.dart';
 
 class DarkAppTheme extends AppTheme {
   DarkAppTheme()
       : super(
-          name: AppThemeType.dark.name,
+          name: ThemeMode.dark.name,
           brightness: Brightness.dark,
           colors: AppThemeColors.fromAppColors(isDarkMode: true),
           styles: const AppThemeStyles(),

--- a/lib/presenter/themes/mode/light_app_theme.dart
+++ b/lib/presenter/themes/mode/light_app_theme.dart
@@ -2,12 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:untitled/presenter/themes/app_theme.dart';
 import 'package:untitled/presenter/themes/app_theme_styles.dart';
 import 'package:untitled/presenter/themes/colors/app_theme_colors.dart';
-import 'package:untitled/presenter/themes/mode/app_theme_type.dart';
 
 class LightAppTheme extends AppTheme {
   LightAppTheme()
       : super(
-          name: AppThemeType.light.name,
+          name: ThemeMode.light.name,
           brightness: Brightness.light,
           colors: AppThemeColors.fromAppColors(isDarkMode: false),
           styles: const AppThemeStyles(),

--- a/lib/presenter/widgets/accounts/account_detail_card.dart
+++ b/lib/presenter/widgets/accounts/account_detail_card.dart
@@ -8,13 +8,13 @@ class AccountDetailsCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // 객체로 가져와야 하지만, 우선은 변수로
-    const String accountNumber = '12345678-01';
+    // 참고로 계좌번호와 AppKey, AppSecret은 사용자 한테 입력 받아야됨
+    const String accountNumber = '12345678-12';
     const String accountType = '위탁계좌';
     const String accountBalance = '14,000,000원';
     final appTheme = Theme.of(context).extension<AppTheme>()!;
 
     return CardLayout(
-      backgroundColor: Theme.of(context).cardColor,
       borderRadius: BorderRadius.circular(14),
       children: [
         Row(
@@ -23,36 +23,19 @@ class AccountDetailsCard extends StatelessWidget {
             Text(
               '$accountNumber $accountType',
               style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                fontWeight: FontWeight.normal,
-                color: Theme.of(context).hintColor,
-                fontSize: 11,
-              ),
-            ),
-            Material(
-              color: Colors.transparent,
-              child: InkWell(
-                borderRadius: BorderRadius.circular(100),
-                onTap: () {},
-                child: const Padding(
-                  padding: EdgeInsets.all(8),
-                  child: Icon(
-                    Icons.copy,
-                    color: Colors.red,
-                    size: 14,
+                    fontWeight: FontWeight.normal,
+                    fontSize: 11,
                   ),
-                ),
-              ),
             ),
           ],
         ),
         Row(
           children: [
-            Text(
+            const Text(
               accountBalance,
               style: TextStyle(
                 fontSize: 32,
                 fontWeight: FontWeight.bold,
-                color: Theme.of(context).colorScheme.primary,
               ),
             ),
             IconButton(
@@ -63,20 +46,18 @@ class AccountDetailsCard extends StatelessWidget {
                   shape: BoxShape.circle,
                 ),
                 padding: const EdgeInsets.all(4),
-                child: Icon(
+                child: const Icon(
                   Icons.arrow_drop_down,
-                  color: appTheme.colors.buttonIconColor,
                   size: 16,
                 ),
               ),
             ),
           ],
         ),
-        Text(
+        const Text(
           'Korea Won (KRW)',
           style: TextStyle(
             fontSize: 11,
-            color: Theme.of(context).hintColor,
           ),
         ),
         const SizedBox(height: 16),

--- a/lib/presenter/widgets/accounts/accounts_trade_history_card.dart
+++ b/lib/presenter/widgets/accounts/accounts_trade_history_card.dart
@@ -32,7 +32,6 @@ class TradeHistoryCard extends StatelessWidget {
     return Padding(
       padding: AppPadding.kHorizontalPadding,
       child: CardLayout(
-        backgroundColor: Theme.of(context).cardColor,
         title: Text(
           'Trade History',
           style: appTheme.typographies.headlineMedium,

--- a/lib/presenter/widgets/card_layout.dart
+++ b/lib/presenter/widgets/card_layout.dart
@@ -6,7 +6,6 @@ class CardLayout extends StatelessWidget {
   final double titleSpacing; // 타이틀과 카드 사이의 간격
   final List<Widget> children;
   final EdgeInsetsGeometry padding; // 카드 내부의 패딩
-  final Color backgroundColor;
   final BorderRadiusGeometry borderRadius;
 
   const CardLayout({
@@ -15,7 +14,6 @@ class CardLayout extends StatelessWidget {
     this.titleSpacing = AppDimensions.medium,
     super.key,
     this.padding = const EdgeInsets.all(12),
-    this.backgroundColor = Colors.white,
     this.borderRadius = const BorderRadius.all(Radius.circular(14)),
   });
 
@@ -28,11 +26,7 @@ class CardLayout extends StatelessWidget {
           title!,
           SizedBox(height: titleSpacing),
         ],
-        Container(
-          decoration: BoxDecoration(
-            color: backgroundColor,
-            borderRadius: BorderRadius.circular(14),
-          ),
+        Card(
           child: Padding(
             padding: padding,
             child: Column(

--- a/lib/presenter/widgets/settings/settings_tile.dart
+++ b/lib/presenter/widgets/settings/settings_tile.dart
@@ -39,7 +39,7 @@ class SettingsTile extends StatelessWidget {
           subtitle: subtitle != null
               ? Text(subtitle!, style: appTheme.typographies.bodySmall)
               : null,
-          trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+          trailing: Icon(Icons.arrow_forward_ios, size: 16, color: appTheme.colors.textColor,),
         ),
       ),
     );

--- a/lib/presenter/widgets/stock_detail/stock_detail_flexible_space_bar.dart
+++ b/lib/presenter/widgets/stock_detail/stock_detail_flexible_space_bar.dart
@@ -111,7 +111,7 @@ Widget StockDetailFlexibleSpaceBar(context) {
                         );
                       },
                     ),
-                    shape: MaterialStateProperty.resolveWith(
+                    shape: WidgetStateProperty.resolveWith(
                           (states) {
                         return RoundedRectangleBorder(
                           borderRadius:


### PR DESCRIPTION
#### 변경 사항

- **Podfile git 추적 제거**: iOS의 `Podfile`을 git에서 제거하고 `.gitignore`에 추가하여 불필요한 파일 관리 문제 해결
- **AppThemeType enum 제거**: 기존의 `AppThemeType` enum을 삭제하고 `ThemeMode`로 대체하여 코드 간결화 및 테마 관리 구조 개선

- **NavigationBar, CardLayout, AppTheme 리팩토링**: 
  - 다크 모드 및 라이트 모드에 맞춘 색상 추가
  - 카드 컴포넌트 디자인 최적화 및 텍스트 스타일 개선
  - 폰트 및 텍스트 스타일 최적화
  - 
- **다크 모드 및 라이트 모드 테마 색상 적용**:
  - `AppColors`에 다크/라이트 모드별 surface, error, onPrimary, onSecondary 등의 색상 추가
  - `AppThemeColors`에서 `isDarkMode`에 따른 테마 색상 적용 로직 수정
  - 문자열 접근 대신 안전한 색상 값 접근 방식으로 개선
  
- **네비게이션 바 인디케이터 애니메이션 최적화**:
  - 애니메이션 속도를 1200ms로 조정하여 더 부드러운 전환을 제공
  - `overlayColor`를 투명하게 설정하여 불필요한 시각적 효과 제거 및 UX 개선

#### 기대 효과
- 코드 가독성 및 유지보수성 향상
- 다크 모드 및 라이트 모드에 따른 일관된 UI 제공
- 네비게이션 바 UX 개선으로 더 부드럽고 직관적인 사용자 경험 제공