### PR TITLE
Feat/google social login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,13 @@ app.*.map.json
 /android/app/debug/
 /android/app/profile/
 /android/app/release/
+android/app/google-services.json
 
 # iOS related (add if needed)
 ios/Flutter/Flutter.framework
 ios/Flutter/Flutter.podspec
 ios/Pods/
 ios/Podfile
+
+# Environment files
+.env

--- a/README.md
+++ b/README.md
@@ -7,18 +7,21 @@
 ```bash
 lib/
 ├── core/                 # 공통적으로 사용되는 유틸리티, 예외 처리, 유스케이스 등
+│   ├── enums/            # 
 │   ├── exceptions/       # 예외 처리 관련 파일
+│   ├── network/          # 
 │   ├── usecases/         # 유스케이스 (비즈니스 로직)
 │   └── utils/            # 공통 유틸리티 파일
 │
 ├── features/             # 각 기능별 모듈 (기능 중심 구조)
 │   ├── feature_a/        # 기능 A 관련 폴더
 │   │   ├── data/         # 데이터 소스, 모델, 리포지토리
-│   │   │   ├── models/     # ( 폴더명을 dto로 변경할지 고민 중 )
-│   │   │   └── repositories/ # 
+│   │   │   ├── models/         # 외부 시스템(API 등)과 데이터를 주고받기 위한 DTO 정의
+│   │   │   ├── repositories/   # 도메인 레이어에서 정의된 레포지토리 인터페이스를 구현하는 클래스
+│   │   │   └── service/        # API 호출 및 외부 서비스와 통신하는 구체적인 서비스 클래스 정의
+│   │   ├── di/           # 의존성 주입 관련 설정 및 모듈 정의
 │   │   ├── domain/       # 엔티티, 유스케이스 등 비즈니스 로직
 │   │   │   ├── entities/     # 비즈니스 객체를 정의하는 엔티티
-│   │   │   ├── service/
 │   │   │   ├── usecases/     # 유스케이스 정의
 │   │   │   └── repositories/ # 도메인 레이어의 리포지토리 인터페이스
 │   │   ├── presentation/ # UI와 관련된 페이지, 뷰모델
@@ -51,18 +54,25 @@ lib/
 ```
 
 ```bash
-## 추가 설명 (auth를 예시로, 이해를 돕기위해 서버에서 데이터를 가져와 처리하는 흐름을 가정. 실제 구현은 클라이언트에서 서버로 데이터를 전달하는 흐름으로, 예시와 정반대로 구현할 예정)
+## 추가 설명 (auth를 예시로 이해를 돕기 위한 설명. 현재 변경 사항이 많아 추후 완료 후 수정할 예정)
 
 lib/
 ├── features/             # 특정 기능(feature)을 정의하는 폴더 (예: Oauth 인증 기능)
 │   ├── auth/             # 인증 관련 기능을 담당하는 폴더
 │   │   ├── data/         # 실제 데이터 소스(API, 외부 서비스 등)와 상호작용하는 계층
 │   │   │   ├── models/        # 서버에서 받은 데이터를 클라이언트에서 사용하기 위한 DTO를 정의
-│   │   │   │   └── auth_user_model.dart  # 서버로부터 받은 JSON 데이터를 DTO로 변환하여 외부 데이터와 상호작용
+│   │   │   │   ├── email_password_user_dto.dart  # 이메일/비밀번호 로그인 관련 데이터를 전송하기 위한 DTO
+│   │   │   │   ├── oauth_user_dto.dart           # OAuth 로그인 관련 데이터를 전송하기 위한 DTO
+│   │   │   │   ├── token_dto.dart                # 인증 토큰 관련 데이터를 전송하기 위한 DTO
+│   │   │   │   └── user_dto.dart                 # 일반적인 사용자 정보를 담은 DTO
 │   │   │   ├── repositories/  # 데이터 소스와 상호작용하여 데이터를 가져오고, DTO를 Entity로 변환하여 도메인 레이어로 전달
-│   │   │   │   ├── auth_repository_impl.dart        # 실제 레포지토리 구현. 서버에서 데이터를 가져오거나 전송하며, DTO를 Entity로 변환하여 도메인 레이어에 전달
-│   │   │   │   ├── apple_auth.dart        # X
-│   │   │   │   └── google_auth.dart       # X
+│   │   │   │   └── auth_repository_impl.dart        # 실제 레포지토리 구현. 서버에서 데이터를 가져오거나 전송하며, DTO를 Entity로 변환하여 도메인 레이어에 전달
+│   │   │   ├── service/       # API 호출 및 외부 서비스와 통신하는 구체적인 서비스 클래스 정의
+│   │   │   │   ├── email_password_login_service.dart  # 이메일/비밀번호 로그인 처리 로직을 담은 서비스 클래스
+│   │   │   │   ├── oauth_login_service.dart           # OAuth 로그인 처리 로직을 담은 서비스 클래스
+│   │   │   │   └── token_service.dart                 # 토큰을 처리하고 API 요청을 관리하는 서비스 클래스
+│   │   ├── di/
+│   │   │   └── auth_module.dart    # Auth 관련 클래스들의 DI 설정을 담당 (MultiProvider에서 사용할 의존성 리스트를 관리)
 │   │   ├── domain/         # 애플리케이션의 비즈니스 로직과 규칙을 처리하는 계층
 │   │   │   ├── entities/      # 도메인 레이어에서 사용하는 데이터 구조를 정의 (비즈니스 로직에 사용되는 엔티티)
 │   │   │   │   └── auth_user_entity.dart  # 레포지토리에서 변환된 DTO를 엔티티로 변환하여 도메인 로직에서 사용

--- a/lib/core/enums/platform_enum.dart
+++ b/lib/core/enums/platform_enum.dart
@@ -1,9 +1,10 @@
 enum PlatformEnum {
   google(id: 'google', token: 'idToken'),
-  apple(id: 'apple', token: 'authorizationToken');
+  apple(id: 'apple', token: 'authorizationToken'),
+  emailPassword(id: 'emailPassword', token: null);
 
   final String id;
-  final String token;
+  final String? token;
 
   const PlatformEnum({required this.id, required this.token});
 

--- a/lib/core/enums/token_enum.dart
+++ b/lib/core/enums/token_enum.dart
@@ -1,0 +1,11 @@
+enum TokenEnum {
+  accessToken(jsonKey: 'access_token'),
+  refreshToken(jsonKey: 'refresh_token');
+
+  final String jsonKey;
+
+  const TokenEnum({
+    required this.jsonKey,
+});
+
+}

--- a/lib/core/exceptions/exceptions.dart
+++ b/lib/core/exceptions/exceptions.dart
@@ -12,3 +12,5 @@ class ThemeProviderException implements Exception {
     return 'ThemeProviderException: $message';
   }
 }
+
+class UnknownPlatformException implements Exception {}

--- a/lib/features/auth/data/models/token_dto.dart
+++ b/lib/features/auth/data/models/token_dto.dart
@@ -1,3 +1,4 @@
+import 'package:untitled/core/enums/token_enum.dart';
 import 'package:untitled/features/auth/domain/entities/token.dart';
 
 class TokenDTO {
@@ -11,15 +12,15 @@ class TokenDTO {
 
   factory TokenDTO.fromJson(Map<String, dynamic> json) {
     return TokenDTO(
-      accessToken: json['access_token'],
-      refreshToken: json['refresh_token'],
+      accessToken: json[TokenEnum.accessToken.jsonKey],
+      refreshToken: json[TokenEnum.refreshToken.jsonKey],
     );
   }
 
   List<Token> toDomain() {
     return [
-      Token(token: accessToken, type: TokenType.access),
-      Token(token: refreshToken, type: TokenType.refresh),
+      Token(token: accessToken, type: TokenEnum.accessToken),
+      Token(token: refreshToken, type: TokenEnum.refreshToken),
     ];
   }
 }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:untitled/core/enums/auth_user_fields.dart';
 import 'package:untitled/core/enums/platform_enum.dart';
 import 'package:untitled/features/auth/data/models/token_dto.dart';
@@ -27,20 +29,31 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   Future<Map<String, dynamic>> loginWithOAuth(PlatformEnum platform) async {
-    /*
-    GoogleSignInAccount._(this._googleSignIn, GoogleSignInUserData data)
-      : displayName = data.displayName,
-        email = data.email,
-        id = data.id,
-        photoUrl = data.photoUrl,
-        serverAuthCode = data.serverAuthCode,
-        _idToken = data.idToken;
-    */
+
+    // 간단하게 구글 로그인 구현 (로그인 실패, 네트워크 문제, 사용자 취소 등 예외 처리 필요)
+    GoogleSignIn googleSignIn = GoogleSignIn(
+      scopes: [
+        'email',
+        'openid',
+      ],
+      serverClientId: dotenv.env['SERVER_CLIENT_ID'],
+    );
+
+    GoogleSignInAccount? account = await googleSignIn.signIn();
+
+    if (account != null) {
+      GoogleSignInAuthentication auth = await account.authentication;
+      return {
+        'oauthId': account.id,
+        'email': account.email,
+        'oauthToken': auth.idToken,
+      };
+    }
 
     return {
-      'oauthId': 'google-id',
-      'email': 'john@gmail.com',
-      'oauthToken': 'google-auth-token',
+      'oauthId': null,
+      'email': null,
+      'oauthToken': null,
     };
   }
 

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -4,6 +4,7 @@ import 'package:untitled/core/exceptions/exceptions.dart';
 import 'package:untitled/features/auth/data/service/email_password_login_service.dart';
 import 'package:untitled/features/auth/data/service/oauth_login_service.dart';
 import 'package:untitled/features/auth/data/service/token_service.dart';
+import 'package:untitled/features/auth/data/storage/token_storage.dart';
 import 'package:untitled/features/auth/domain/entities/email_password_user_entity.dart';
 import 'package:untitled/features/auth/domain/entities/oauth_user_entity.dart';
 import 'package:untitled/features/auth/domain/entities/token.dart';
@@ -14,11 +15,13 @@ class AuthRepositoryImpl implements AuthRepository {
   final OAuthLoginService oAuthLoginService;
   final EmailPasswordLoginService emailPasswordLoginService;
   final TokenService tokenService;
+  final TokenStorage tokenStorage;
 
   AuthRepositoryImpl({
     required this.oAuthLoginService,
     required this.emailPasswordLoginService,
     required this.tokenService,
+    required this.tokenStorage,
   });
 
   @override
@@ -61,5 +64,16 @@ class AuthRepositoryImpl implements AuthRepository {
   Future<List<Token>> requestToken(UserEntity user) async {
     final response = await tokenService.requestTokenFromServer(user);
     return tokenService.parseTokens(response);
+  }
+
+  @override
+  Future<void> saveTokens(List<Token> tokens) async {
+    tokenStorage.saveTokens(tokens);
+  }
+
+
+  @override
+  Future<void> logout(UserEntity user) async{
+    print('${user.platform}, ${user.email}');
   }
 }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,77 +1,65 @@
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:google_sign_in/google_sign_in.dart';
 import 'package:untitled/core/enums/auth_user_fields.dart';
 import 'package:untitled/core/enums/platform_enum.dart';
-import 'package:untitled/features/auth/data/models/token_dto.dart';
+import 'package:untitled/core/exceptions/exceptions.dart';
+import 'package:untitled/features/auth/data/service/email_password_login_service.dart';
+import 'package:untitled/features/auth/data/service/oauth_login_service.dart';
+import 'package:untitled/features/auth/data/service/token_service.dart';
+import 'package:untitled/features/auth/domain/entities/email_password_user_entity.dart';
 import 'package:untitled/features/auth/domain/entities/oauth_user_entity.dart';
 import 'package:untitled/features/auth/domain/entities/token.dart';
 import 'package:untitled/features/auth/domain/entities/user_entity.dart';
 import 'package:untitled/features/auth/domain/repositories/auth_repository.dart';
 
 class AuthRepositoryImpl implements AuthRepository {
+  final OAuthLoginService oAuthLoginService;
+  final EmailPasswordLoginService emailPasswordLoginService;
+  final TokenService tokenService;
+
+  AuthRepositoryImpl({
+    required this.oAuthLoginService,
+    required this.emailPasswordLoginService,
+    required this.tokenService,
+  });
+
   @override
   Future<UserEntity> login(PlatformEnum platform) async {
-    final response = await loginWithOAuth(platform);
-
-    // TODO: 여기에 oauth, emailpassword 로그인 분리해서 각자 리턴해줘야함
-    // 이건 oauth 리턴
-    return OAuthUserEntity(
-      oauthId: response[AuthUserFields.oAuthId.key],
-      email: response[AuthUserFields.email.key],
-      oauthToken: response[AuthUserFields.oAuthToken.key],
-      platform: platform.id,
-    );
-
-    // E/P Login으로 한다면, final response = await loginWithEmailPassword();
-    // return EmailPasswordUserEntity( ... ); 같은 형태가 되겠지
-    // 어차피 UserEntity를 상속하는 Entity들이라 RequestToken을 통해 토큰 응답도 정상적으로 받을 수 있고
-    // 다만, platform 필드를 통해 서버에서 어떤 방식으로 요청하는지 구분해서 인증처리 해야됨
+    final response = await _loginBasedOnPlatform(platform);
+    return _createUserEntity(platform, response);
   }
 
-  Future<Map<String, dynamic>> loginWithOAuth(PlatformEnum platform) async {
-
-    // 간단하게 구글 로그인 구현 (로그인 실패, 네트워크 문제, 사용자 취소 등 예외 처리 필요)
-    GoogleSignIn googleSignIn = GoogleSignIn(
-      scopes: [
-        'email',
-        'openid',
-      ],
-      serverClientId: dotenv.env['SERVER_CLIENT_ID'],
-    );
-
-    GoogleSignInAccount? account = await googleSignIn.signIn();
-
-    if (account != null) {
-      GoogleSignInAuthentication auth = await account.authentication;
-      return {
-        'oauthId': account.id,
-        'email': account.email,
-        'oauthToken': auth.idToken,
-      };
+  Future<Map<String, dynamic>> _loginBasedOnPlatform(PlatformEnum platform) {
+    if (platform == PlatformEnum.apple || platform == PlatformEnum.google) {
+      return oAuthLoginService.loginWithOAuth(platform);
+    } else if (platform == PlatformEnum.emailPassword) {
+      return emailPasswordLoginService.loginWithEmailPassword();
     }
+    throw UnknownPlatformException;
+  }
 
-    return {
-      'oauthId': null,
-      'email': null,
-      'oauthToken': null,
-    };
+  UserEntity _createUserEntity(
+    PlatformEnum platform,
+    Map<String, dynamic> response,
+  ) {
+    if (platform == PlatformEnum.apple || platform == PlatformEnum.google) {
+      return OAuthUserEntity(
+        oauthId: response[AuthUserFields.oAuthId.key],
+        email: response[AuthUserFields.email.key],
+        oauthToken: response[AuthUserFields.oAuthToken.key],
+        platform: platform.id,
+      );
+    } else if (platform == PlatformEnum.emailPassword) {
+      return EmailPasswordUserEntity(
+        email: response[AuthUserFields.email.key],
+        password: response[AuthUserFields.password.key],
+        platform: platform.id,
+      );
+    }
+    throw UnknownPlatformException;
   }
 
   @override
   Future<List<Token>> requestToken(UserEntity user) async {
-    final response = await serverRequestToken(user);
-    final tokenDTO = TokenDTO.fromJson(response);
-    final List<Token> tokens = tokenDTO.toDomain();
-    return tokens;
-  }
-
-  Future<Map<String, dynamic>> serverRequestToken(UserEntity user) async {
-    // TODO: UserEntity를 상속받은 자식타입 객체들을 fromEntity를 통해 DTO로 변환 후 서버에 전달해야 됨
-    // 서버에서는 platform 필드로 구분해서 인증 후 DB에 저장하고 토큰 발급하고 하면 됨
-    const response = {
-      "access_token": "abcd1234",
-      "refresh_token": "xyz9876",
-    };
-    return response;
+    final response = await tokenService.requestTokenFromServer(user);
+    return tokenService.parseTokens(response);
   }
 }

--- a/lib/features/auth/data/service/email_password_login_service.dart
+++ b/lib/features/auth/data/service/email_password_login_service.dart
@@ -1,0 +1,9 @@
+class EmailPasswordLoginService {
+  Future<Map<String, dynamic>> loginWithEmailPassword() async {
+      print('what the fuck');
+      return {
+        'email': '',
+        'password':'',
+      };
+    }
+}

--- a/lib/features/auth/data/service/oauth_login_service.dart
+++ b/lib/features/auth/data/service/oauth_login_service.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:untitled/core/enums/platform_enum.dart';
+
+class OAuthLoginService {
+  Future<Map<String, dynamic>> loginWithOAuth(PlatformEnum platform) async {
+
+    // 간단하게 구글 로그인 구현 (로그인 실패, 네트워크 문제, 사용자 취소 등 예외 처리 필요)
+    GoogleSignIn googleSignIn = GoogleSignIn(
+      scopes: [
+        'email',
+        'openid',
+      ],
+      serverClientId: dotenv.env['SERVER_CLIENT_ID'],
+    );
+
+    GoogleSignInAccount? account = await googleSignIn.signIn();
+
+    if (account != null) {
+      GoogleSignInAuthentication auth = await account.authentication;
+      return {
+        'oauthId': account.id,
+        'email': account.email,
+        'oauthToken': auth.idToken,
+      };
+    }
+
+    return {
+      'oauthId': null,
+      'email': null,
+      'oauthToken': null,
+    };
+  }
+}

--- a/lib/features/auth/data/service/token_service.dart
+++ b/lib/features/auth/data/service/token_service.dart
@@ -12,10 +12,7 @@ class TokenService {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: jsonEncode({
-        'platform': user.platform,
-        'email': user.email,
-      }),
+      body: jsonEncode(user.toJson()),
     );
 
     if (response.statusCode == HttpStatus.ok) {

--- a/lib/features/auth/data/service/token_service.dart
+++ b/lib/features/auth/data/service/token_service.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:untitled/features/auth/data/models/token_dto.dart';
+import 'package:untitled/features/auth/domain/entities/token.dart';
+import 'package:untitled/features/auth/domain/entities/user_entity.dart';
+
+class TokenService {
+  Future<Map<String, dynamic>> requestTokenFromServer(UserEntity user) async {
+    final response = await http.post(
+      Uri.parse('http://192.168.0.36:8080/api/auth/login'),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({
+        'platform': user.platform,
+        'email': user.email,
+      }),
+    );
+
+    if (response.statusCode == HttpStatus.ok) {
+      final Map<String, dynamic> responseData = jsonDecode(response.body);
+      return {
+        'access_token': responseData['accessToken'],
+        'refresh_token': responseData['refreshToken'],
+      };
+    } else {
+      throw Exception('Failed to authenticate with server');
+    }
+  }
+
+  List<Token> parseTokens(Map<String, dynamic> responseData) {
+    final tokenDTO = TokenDTO.fromJson(responseData);
+    return tokenDTO.toDomain();
+  }
+}

--- a/lib/features/auth/data/service/token_service.dart
+++ b/lib/features/auth/data/service/token_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
+import 'package:untitled/core/enums/token_enum.dart';
 import 'package:untitled/features/auth/data/models/token_dto.dart';
 import 'package:untitled/features/auth/domain/entities/token.dart';
 import 'package:untitled/features/auth/domain/entities/user_entity.dart';
@@ -18,8 +19,8 @@ class TokenService {
     if (response.statusCode == HttpStatus.ok) {
       final Map<String, dynamic> responseData = jsonDecode(response.body);
       return {
-        'access_token': responseData['accessToken'],
-        'refresh_token': responseData['refreshToken'],
+        TokenEnum.accessToken.jsonKey: responseData['accessToken'],
+        TokenEnum.refreshToken.jsonKey: responseData['refreshToken'],
       };
     } else {
       throw Exception('Failed to authenticate with server');

--- a/lib/features/auth/data/service/user_service.dart
+++ b/lib/features/auth/data/service/user_service.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:untitled/core/enums/auth_user_fields.dart';
+import 'package:untitled/features/auth/domain/entities/token.dart';
+import 'package:untitled/features/auth/domain/entities/user_entity.dart';
+
+class UserService {
+  Future<UserEntity> getUserByAccessToken(Token accessToken) async {
+    final token = accessToken.token;
+    final response = await http.get(
+      Uri.parse('http://192.168.0.36:8080/api/auth/user'),
+      headers: {
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == HttpStatus.ok) {
+      final data = jsonDecode(response.body);
+      return UserEntity(
+        email: data[AuthUserFields.email.key],
+        platform: data[AuthUserFields.platform.key],
+      );
+    } else {
+      throw Exception('Failed to fetch user');
+    }
+  }
+}

--- a/lib/features/auth/data/storage/token_storage.dart
+++ b/lib/features/auth/data/storage/token_storage.dart
@@ -1,0 +1,37 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:untitled/core/enums/token_enum.dart';
+import 'package:untitled/features/auth/domain/entities/token.dart';
+
+class TokenStorage {
+  Future<void> saveTokens(List<Token> tokens) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    final accessToken = tokens.firstWhere((token) => token.type == TokenEnum.accessToken);
+    final refreshToken = tokens.firstWhere((token) => token.type == TokenEnum.refreshToken);
+
+    await prefs.setString('access_token', accessToken.token);
+    await prefs.setString('refresh_token', refreshToken.token);
+  }
+
+  Future<List<Token>> loadTokens() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    final accessToken = prefs.getString(TokenEnum.accessToken.jsonKey);
+    final refreshToken = prefs.getString(TokenEnum.refreshToken.jsonKey);
+
+    if (accessToken != null && refreshToken != null) {
+      return [
+        Token(token: accessToken, type: TokenEnum.accessToken),
+        Token(token: refreshToken, type: TokenEnum.refreshToken),
+      ];
+    } else {
+      throw Exception('No tokens found');
+    }
+  }
+
+  Future<void> clearTokens() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.remove(TokenEnum.accessToken.jsonKey);
+    await prefs.remove(TokenEnum.refreshToken.jsonKey);
+  }
+}

--- a/lib/features/auth/di/auth_module.dart
+++ b/lib/features/auth/di/auth_module.dart
@@ -1,0 +1,25 @@
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+import 'package:untitled/features/auth/data/repositories/auth_repository_impl.dart';
+import 'package:untitled/features/auth/data/service/email_password_login_service.dart';
+import 'package:untitled/features/auth/data/service/oauth_login_service.dart';
+import 'package:untitled/features/auth/data/service/token_service.dart';
+import 'package:untitled/features/auth/domain/repositories/auth_repository.dart';
+import 'package:untitled/features/auth/domain/usecases/login_usecase.dart';
+
+class AuthModule {
+  static List<SingleChildWidget> providers = [
+    Provider<AuthRepository>(
+      create: (context) => AuthRepositoryImpl(
+        emailPasswordLoginService: EmailPasswordLoginService(),
+        oAuthLoginService: OAuthLoginService(),
+        tokenService: TokenService(),
+      ),
+    ),
+    Provider<LoginUseCase>(
+      create: (context) => LoginUseCase(
+        Provider.of<AuthRepository>(context, listen: false),
+      ),
+    ),
+  ];
+}

--- a/lib/features/auth/di/auth_module.dart
+++ b/lib/features/auth/di/auth_module.dart
@@ -4,21 +4,36 @@ import 'package:untitled/features/auth/data/repositories/auth_repository_impl.da
 import 'package:untitled/features/auth/data/service/email_password_login_service.dart';
 import 'package:untitled/features/auth/data/service/oauth_login_service.dart';
 import 'package:untitled/features/auth/data/service/token_service.dart';
+import 'package:untitled/features/auth/data/service/user_service.dart';
+import 'package:untitled/features/auth/data/storage/token_storage.dart';
 import 'package:untitled/features/auth/domain/repositories/auth_repository.dart';
 import 'package:untitled/features/auth/domain/usecases/login_usecase.dart';
+import 'package:untitled/features/auth/domain/usecases/logout_usecase.dart';
 
+/*
+* TODO: 생성 순서 및 사용처에 따라 정리 필요
+*/
 class AuthModule {
   static List<SingleChildWidget> providers = [
+    Provider<TokenService>(create: (_) => TokenService()),
+    Provider<TokenStorage>(create: (_) => TokenStorage()),
+    Provider<UserService>(create: (_) => UserService()),
     Provider<AuthRepository>(
       create: (context) => AuthRepositoryImpl(
         emailPasswordLoginService: EmailPasswordLoginService(),
         oAuthLoginService: OAuthLoginService(),
-        tokenService: TokenService(),
+        tokenService: Provider.of<TokenService>(context, listen: false),
+        tokenStorage: Provider.of<TokenStorage>(context, listen: false),
       ),
     ),
     Provider<LoginUseCase>(
       create: (context) => LoginUseCase(
-        Provider.of<AuthRepository>(context, listen: false),
+        repository: Provider.of<AuthRepository>(context, listen: false),
+      ),
+    ),
+    Provider<LogoutUseCase>(
+      create: (context) => LogoutUseCase(
+        repository: Provider.of<AuthRepository>(context, listen: false),
       ),
     ),
   ];

--- a/lib/features/auth/domain/entities/email_password_user_entity.dart
+++ b/lib/features/auth/domain/entities/email_password_user_entity.dart
@@ -1,3 +1,4 @@
+import 'package:untitled/core/enums/auth_user_fields.dart';
 import 'package:untitled/features/auth/domain/entities/user_entity.dart';
 
 class EmailPasswordUserEntity extends UserEntity {
@@ -8,4 +9,13 @@ class EmailPasswordUserEntity extends UserEntity {
     required this.password,
     required super.platform,
   });
+
+  @override
+  Map<String, dynamic> toJson() {
+    final json = super.toJson();
+    json.addAll({
+      AuthUserFields.password.key: password,
+    });
+    return json;
+  }
 }

--- a/lib/features/auth/domain/entities/oauth_user_entity.dart
+++ b/lib/features/auth/domain/entities/oauth_user_entity.dart
@@ -1,3 +1,4 @@
+import 'package:untitled/core/enums/auth_user_fields.dart';
 import 'package:untitled/features/auth/domain/entities/user_entity.dart';
 
 class OAuthUserEntity extends UserEntity {
@@ -14,5 +15,15 @@ class OAuthUserEntity extends UserEntity {
   @override
   String toString() {
     return 'OAuthUserEntity(oauthId: $oauthId, email: $email, oauthToken: $oauthToken, platform: $platform)';
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    final json = super.toJson();
+    json.addAll({
+      AuthUserFields.oAuthId.key: oauthId,
+      AuthUserFields.oAuthToken.key: oauthToken,
+    });
+    return json;
   }
 }

--- a/lib/features/auth/domain/entities/oauth_user_entity.dart
+++ b/lib/features/auth/domain/entities/oauth_user_entity.dart
@@ -10,4 +10,9 @@ class OAuthUserEntity extends UserEntity {
     required this.oauthToken,
     required super.platform,
   });
+
+  @override
+  String toString() {
+    return 'OAuthUserEntity(oauthId: $oauthId, email: $email, oauthToken: $oauthToken, platform: $platform)';
+  }
 }

--- a/lib/features/auth/domain/entities/token.dart
+++ b/lib/features/auth/domain/entities/token.dart
@@ -1,11 +1,8 @@
-enum TokenType {
-  access,
-  refresh;
-}
+import 'package:untitled/core/enums/token_enum.dart';
 
 class Token {
   final String token;
-  final TokenType type;
+  final TokenEnum type;
 
   Token({
     required this.token,

--- a/lib/features/auth/domain/entities/user_entity.dart
+++ b/lib/features/auth/domain/entities/user_entity.dart
@@ -1,6 +1,6 @@
 import 'package:untitled/core/enums/auth_user_fields.dart';
 
-abstract class UserEntity {
+class UserEntity {
   final String email;
   final String platform;
 

--- a/lib/features/auth/domain/entities/user_entity.dart
+++ b/lib/features/auth/domain/entities/user_entity.dart
@@ -1,3 +1,5 @@
+import 'package:untitled/core/enums/auth_user_fields.dart';
+
 abstract class UserEntity {
   final String email;
   final String platform;
@@ -6,4 +8,11 @@ abstract class UserEntity {
     required this.email,
     required this.platform,
   });
+
+  Map<String, dynamic> toJson() {
+    return {
+      AuthUserFields.email.key: email,
+      AuthUserFields.platform.key: platform,
+    };
+  }
 }

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -5,4 +5,6 @@ import 'package:untitled/features/auth/domain/entities/user_entity.dart';
 abstract interface class AuthRepository {
   Future<UserEntity> login(PlatformEnum platform);
   Future<List<Token>> requestToken(UserEntity user);
+  Future<void> saveTokens(List<Token> tokens);
+  Future<void> logout(UserEntity user);
 }

--- a/lib/features/auth/domain/usecases/login_usecase.dart
+++ b/lib/features/auth/domain/usecases/login_usecase.dart
@@ -12,13 +12,13 @@ class LoginParams {
 class LoginUseCase extends UseCase<List<Token>, LoginParams> {
   final AuthRepository repository;
 
-  LoginUseCase(this.repository);
+  LoginUseCase({required this.repository});
 
   @override
   Future<List<Token>> call(LoginParams params) async {
     final authUser = await repository.login(params.platform);
     final List<Token> tokens = await repository.requestToken(authUser);
-
+    await repository.saveTokens(tokens);
     return tokens;
   }
 }

--- a/lib/features/auth/domain/usecases/logout_usecase.dart
+++ b/lib/features/auth/domain/usecases/logout_usecase.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+import 'package:untitled/core/usecases/usecase.dart';
+import 'package:untitled/features/auth/domain/entities/user_entity.dart';
+import 'package:untitled/features/auth/domain/repositories/auth_repository.dart';
+
+class LogoutParams {
+  final UserEntity user;
+
+  LogoutParams({required this.user});
+}
+
+class LogoutUseCase extends UseCase<void, LogoutParams> {
+  final AuthRepository repository;
+
+  LogoutUseCase({required this.repository});
+
+  @override
+  FutureOr<void> call(LogoutParams params) async {
+    await repository.logout(params.user);
+  }
+}

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -24,7 +24,6 @@ class _LoginPageState extends State<LoginPage> {
 
     try {
       final loginUseCase = Provider.of<LoginUseCase>(context, listen: false);
-
       final tokens = await loginUseCase(LoginParams(platform: platform));
       setState(() {
         _message = '로그인 성공! 받은 토큰: $tokens';
@@ -36,6 +35,8 @@ class _LoginPageState extends State<LoginPage> {
         MaterialPageRoute(builder: (context) => const MainScreen()),
       );
     } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('로그인 실패: $e')));
       setState(() {
         _message = '로그인 실패: $e';
       });

--- a/lib/features/auth/presentation/pages/test_login_ui.dart
+++ b/lib/features/auth/presentation/pages/test_login_ui.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:untitled/core/enums/platform_enum.dart';
 import 'package:untitled/core/utils/constants.dart';
+import 'package:untitled/features/auth/domain/usecases/login_usecase.dart';
 import 'package:untitled/features/auth/presentation/pages/login_text_field.dart';
+import 'package:untitled/main.dart';
 import 'package:untitled/themes/extensions.dart';
 
 class TestLoginUi extends StatefulWidget {
@@ -12,13 +15,43 @@ class TestLoginUi extends StatefulWidget {
 }
 
 class _TestLoginUiState extends State<TestLoginUi> {
+  bool _isLoading = false;
+  String? _message;
+
+  Future<void> _handleLogin(PlatformEnum platform, BuildContext context) async {
+    setState(() {
+      _isLoading = true;
+      _message = null;
+    });
+
+    try {
+      final loginUseCase = Provider.of<LoginUseCase>(context, listen: false);
+      final tokens = await loginUseCase(LoginParams(platform: platform));
+      setState(() {
+        _message = '로그인 성공! 받은 토큰: $tokens';
+      });
+
+      await Future.delayed(const Duration(seconds: 2));
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const MainScreen()),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('로그인 실패: $e')));
+      setState(() {
+        _message = '로그인 실패: $e';
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+
   @override
   Widget build(BuildContext context) {
-
-    Future<void> _handleLogin(PlatformEnum platform, BuildContext context) async {
-
-    }
-
 
     return SafeArea(
       child: Scaffold(

--- a/lib/features/auth/presentation/pages/test_login_ui.dart
+++ b/lib/features/auth/presentation/pages/test_login_ui.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:untitled/core/enums/platform_enum.dart';
 import 'package:untitled/core/utils/constants.dart';
 import 'package:untitled/features/auth/presentation/pages/login_text_field.dart';
 import 'package:untitled/themes/extensions.dart';
@@ -13,6 +14,12 @@ class TestLoginUi extends StatefulWidget {
 class _TestLoginUiState extends State<TestLoginUi> {
   @override
   Widget build(BuildContext context) {
+
+    Future<void> _handleLogin(PlatformEnum platform, BuildContext context) async {
+
+    }
+
+
     return SafeArea(
       child: Scaffold(
         backgroundColor: context.colors.scaffoldBackground,
@@ -61,7 +68,9 @@ class _TestLoginUiState extends State<TestLoginUi> {
               ),
               Spacing.mediumHeight(),
               ElevatedButton(
-                onPressed: () {},
+                onPressed: () {
+                  _handleLogin(PlatformEnum.emailPassword, context);
+                },
                 style: ElevatedButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 14),
                   shape: RoundedRectangleBorder(

--- a/lib/features/auth/presentation/viewmodels/user_session_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/user_session_provider.dart
@@ -1,5 +1,0 @@
-import 'package:flutter/cupertino.dart';
-
-class TokenProvider with ChangeNotifier {
-
-}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:untitled/features/auth/data/repositories/auth_repository_impl.dart';
+import 'package:untitled/features/auth/data/service/email_password_login_service.dart';
+import 'package:untitled/features/auth/data/service/oauth_login_service.dart';
+import 'package:untitled/features/auth/data/service/token_service.dart';
+import 'package:untitled/features/auth/di/auth_module.dart';
 import 'package:untitled/features/auth/domain/repositories/auth_repository.dart';
 import 'package:untitled/features/auth/domain/usecases/login_usecase.dart';
 import 'package:untitled/features/auth/presentation/pages/login_page.dart';
@@ -15,7 +19,6 @@ import 'package:untitled/themes/mode/dark_app_theme.dart';
 import 'package:untitled/themes/mode/light_app_theme.dart';
 
 void main() async {
-
   WidgetsFlutterBinding.ensureInitialized();
 
   await dotenv.load(fileName: '.env');
@@ -25,12 +28,7 @@ void main() async {
       providers: [
         ChangeNotifierProvider(create: (context) => ThemeProvider()),
         // ChangeNotifierProvider(create: (context) => UserSessionProvider()),
-        Provider<AuthRepository>(create: (context) => AuthRepositoryImpl()),
-        Provider<LoginUseCase>(
-          create: (context) => LoginUseCase(
-            Provider.of<AuthRepository>(context, listen: false),
-          ),
-        ),
+        ...AuthModule.providers,
       ],
       child: const MyApp(),
     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:untitled/features/auth/data/repositories/auth_repository_impl.dart';
 import 'package:untitled/features/auth/domain/repositories/auth_repository.dart';
@@ -13,7 +14,12 @@ import 'package:untitled/providers/theme_provider.dart';
 import 'package:untitled/themes/mode/dark_app_theme.dart';
 import 'package:untitled/themes/mode/light_app_theme.dart';
 
-void main() {
+void main() async {
+
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await dotenv.load(fileName: '.env');
+
   runApp(
     MultiProvider(
       providers: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -94,6 +94,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: "9357883bdd153ab78cbf9ffa07656e336b8bbb2b5a3ca596b0b27e119f7c7d77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,6 +125,54 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5be191523702ba8d7a01ca97c17fca096822ccf246b0a9f11923a6ded06199b6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1+4"
+  google_sign_in:
+    dependency: "direct main"
+    description:
+      name: google_sign_in
+      sha256: "0b8787cb9c1a68ad398e8010e8c8766bfa33556d2ab97c439fb4137756d7308f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
+  google_sign_in_android:
+    dependency: transitive
+    description:
+      name: google_sign_in_android
+      sha256: "0608de03fc541ece4f91ba3e01a68b17cce7a6cf42bd59e40bbe5c55cc3a49d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.30"
+  google_sign_in_ios:
+    dependency: transitive
+    description:
+      name: google_sign_in_ios
+      sha256: "4898410f55440049e1ba8f15411612d9f89299d89c61cd9baf7e02d56ff81ac7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.7"
+  google_sign_in_platform_interface:
+    dependency: transitive
+    description:
+      name: google_sign_in_platform_interface
+      sha256: "1f6e5787d7a120cc0359ddf315c92309069171306242e181c09472d1b00a2971"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.5"
+  google_sign_in_web:
+    dependency: transitive
+    description:
+      name: google_sign_in_web
+      sha256: "042805a21127a85b0dc46bba98a37926f17d2439720e8a459d27045d8ef68055"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.4+2"
   http:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -182,7 +182,7 @@ packages:
     source: hosted
     version: "0.12.4+2"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   animations: ^2.0.11
   flutter_svg: ^2.0.10+1
   shared_preferences: ^2.3.2
+  google_sign_in: ^6.2.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   flutter_svg: ^2.0.10+1
   shared_preferences: ^2.3.2
   google_sign_in: ^6.2.1
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:
@@ -68,6 +69,7 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
     - assets/symbols/
+    - .env
   # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   shared_preferences: ^2.3.2
   google_sign_in: ^6.2.1
   flutter_dotenv: ^5.1.0
+  http: ^1.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 주요 변경 사항:
- Google OAuth 로그인 구현 및 dotenv 적용
  - dotenv 패키지를 통해 `serverClientId`를 .env 파일에서 불러오도록 처리
  - Google 로그인 간략하게 구현 (로그인 실패, 네트워크 문제 등 미완료)
  
- AuthModule 모듈화 및 DI 적용
  - AuthRepositoryImpl의 서비스 로직을 분리하여 DI 적용
  - main 클래스에서 AuthModule을 통해 MultiProvider 설정

- 로그아웃 및 사용자 정보 조회 기능 추가
  - LogoutUseCase 구현
  - TokenStorage를 통해 SharedPreferences에 토큰 저장 및 로드 처리
  - UserService를 통해 토큰으로 사용자 정보 조회 (현재 더미 데이터 반환)
  
- 기타
  - UserEntity와 그 자식 클래스의 `toJson` 메서드 추가
  - Settings 페이지에 로그아웃 기능 추가 (현재 요청 후 서버에서 더미데이터 응답, 추후 세부 기능 구현 예정)
